### PR TITLE
Added support for timeout to FakeXMLHttpRequest.

### DIFF
--- a/lib/fake-server/fake-server-with-clock.test.js
+++ b/lib/fake-server/fake-server-with-clock.test.js
@@ -198,6 +198,20 @@ describe("fakeServerWithClock", function () {
             assert(respond.calledWith("GET", "/", ""));
             assert(respond.calledOn(this.server));
         });
+
+        it("does not trigger a timeout event", function () {
+            sandbox = sinon.sandbox.create();
+
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/");
+            xhr.timeout = 1;
+            xhr.triggerTimeout = sandbox.spy();
+            xhr.send();
+
+            this.server.respond();
+
+            assert.isFalse(xhr.triggerTimeout.called);
+        });
     });
 
     describe("jQuery compat mode", function () {

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -34,6 +34,8 @@ sinonXhr.GlobalActiveXObject = global.ActiveXObject;
 sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject !== "undefined";
 sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest !== "undefined";
 sinonXhr.workingXHR = getWorkingXHR(global);
+sinonXhr.supportsTimeout =
+    (sinonXhr.supportsXHR && "timeout" in (new sinonXhr.GlobalXMLHttpRequest()));
 sinonXhr.supportsCORS = isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
@@ -93,6 +95,11 @@ function FakeXMLHttpRequest(config) {
     this.responseType = "";
     this.response = "";
     this.logError = configureLogError(config);
+
+    if (sinonXhr.supportsTimeout) {
+        this.timeout = 0;
+    }
+
     if (sinonXhr.supportsCORS) {
         this.withCredentials = false;
     }
@@ -270,6 +277,23 @@ function clearResponse(xhr) {
     xhr.responseXML = null;
 }
 
+/**
+ * Steps to follow when there is an error, according to:
+ * https://xhr.spec.whatwg.org/#request-error-steps
+ */
+function requestErrorSteps(xhr) {
+    clearResponse(xhr);
+    xhr.errorFlag = true;
+    xhr.requestHeaders = {};
+    xhr.responseHeaders = {};
+
+    if (xhr.readyState !== FakeXMLHttpRequest.UNSENT && xhr.sendFlag
+        && xhr.readyState !== FakeXMLHttpRequest.DONE) {
+        xhr.readyStateChange(FakeXMLHttpRequest.DONE);
+        xhr.sendFlag = false;
+    }
+}
+
 FakeXMLHttpRequest.parseXML = function parseXML(text) {
     // Treat empty string as parsing failure
     if (text !== "") {
@@ -376,9 +400,9 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         if (this.readyState === FakeXMLHttpRequest.DONE) {
-            if (this.aborted || this.status === 0) {
+            if (this.timedOut || this.aborted || this.status === 0) {
                 progress = {loaded: 0, total: 0};
-                event = this.aborted ? "abort" : "error";
+                event = (this.timedOut && "timeout") || (this.aborted && "abort") || "error";
             } else {
                 progress = {loaded: 100, total: 100};
                 event = "load";
@@ -467,22 +491,38 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
             this.onSend(this);
         }
 
+        // Only listen if setInterval and Date are a stubbed.
+        if (sinonXhr.supportsTimeout && typeof setInterval.clock === "object" && typeof Date.clock === "object") {
+            var initiatedTime = Date.now();
+            var self = this;
+
+            // Listen to any possible tick by fake timers and check to see if timeout has
+            // been exceeded. It's important to note that timeout can be changed while a request
+            // is in flight, so we must check anytime the end user forces a clock tick to make
+            // sure timeout hasn't changed.
+            // https://xhr.spec.whatwg.org/#dfnReturnLink-2
+            var clearIntervalId = setInterval(function () {
+                // Check if the readyState has been reset or is done. If this is the case, there
+                // should be no timeout. This will also prevent aborted requests and
+                // fakeServerWithClock from triggering unnecessary responses.
+                if (self.readyState === FakeXMLHttpRequest.UNSENT
+                  || self.readyState === FakeXMLHttpRequest.DONE) {
+                    clearInterval(clearIntervalId);
+                } else if (typeof self.timeout === "number" && self.timeout > 0) {
+                    if (Date.now() >= (initiatedTime + self.timeout)) {
+                        self.triggerTimeout();
+                        clearInterval(clearIntervalId);
+                    }
+                }
+            }, 1);
+        }
+
         this.dispatchEvent(new sinonEvent.Event("loadstart", false, false, this));
     },
 
     abort: function abort() {
         this.aborted = true;
-        clearResponse(this);
-        this.errorFlag = true;
-        this.requestHeaders = {};
-        this.responseHeaders = {};
-
-        if (this.readyState !== FakeXMLHttpRequest.UNSENT && this.sendFlag
-            && this.readyState !== FakeXMLHttpRequest.DONE) {
-            this.readyStateChange(FakeXMLHttpRequest.DONE);
-            this.sendFlag = false;
-        }
-
+        requestErrorSteps(this);
         this.readyState = FakeXMLHttpRequest.UNSENT;
     },
 
@@ -493,6 +533,13 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         this.responseHeaders = {};
 
         this.readyStateChange(FakeXMLHttpRequest.DONE);
+    },
+
+    triggerTimeout: function triggerTimeout() {
+        if (sinonXhr.supportsTimeout) {
+            this.timedOut = true;
+            requestErrorSteps(this);
+        }
     },
 
     getResponseHeader: function getResponseHeader(header) {

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -106,7 +106,7 @@ function assertEventOrdering(event, progress, callback) {
 
         // listen for abort, error, and load events to make sure only
         // the expected events fire
-        ["abort", "error", "load"].forEach(
+        ["abort", "timeout", "error", "load"].forEach(
             function (name) {
                 this.xhr.upload.addEventListener(name, observe("upload:" + name));
                 this.xhr.addEventListener(name, observe("xhr:" + name));
@@ -116,6 +116,116 @@ function assertEventOrdering(event, progress, callback) {
         );
 
         callback(this.xhr);
+    });
+}
+
+function assertRequestErrorSteps(callback) {
+    it("sets response to empty string", function () {
+        this.xhr.response = "Partial data";
+
+        callback(this.xhr);
+
+        assert.same(this.xhr.response, "");
+    });
+
+    it("sets responseText to empty string", function () {
+        this.xhr.responseText = "Partial data";
+
+        callback(this.xhr);
+
+        assert.same(this.xhr.responseText, "");
+    });
+
+    it("sets errorFlag to true", function () {
+        callback(this.xhr);
+
+        assert.isTrue(this.xhr.errorFlag);
+    });
+
+    it("nulls request headers", function () {
+        this.xhr.open("GET", "/");
+        this.xhr.setRequestHeader("X-Test", "Sumptn");
+
+        callback(this.xhr);
+
+        assert.equals(this.xhr.requestHeaders, {});
+    });
+
+    it("does not have undefined response headers", function () {
+        this.xhr.open("GET", "/");
+
+        callback(this.xhr);
+
+        assert.defined(this.xhr.responseHeaders);
+    });
+
+    it("nulls response headers", function () {
+        this.xhr.open("GET", "/");
+
+        callback(this.xhr);
+
+        assert.equals(this.xhr.responseHeaders, {});
+    });
+
+    it("signals onreadystatechange with state set to DONE if sent before", function () {
+        var readyState;
+        this.xhr.open("GET", "/");
+        this.xhr.send();
+
+        this.xhr.onreadystatechange = function () {
+            readyState = this.readyState;
+        };
+
+        callback(this.xhr);
+
+        assert.equals(readyState, FakeXMLHttpRequest.DONE);
+    });
+
+    it("sets send flag to false if sent before", function () {
+        this.xhr.open("GET", "/");
+        this.xhr.send();
+
+        callback(this.xhr);
+
+        assert.isFalse(this.xhr.sendFlag);
+    });
+
+    it("dispatches readystatechange event if sent before", function () {
+        this.xhr.open("GET", "/");
+        this.xhr.send();
+        this.xhr.onreadystatechange = sinonStub();
+
+        callback(this.xhr);
+
+        assert(this.xhr.onreadystatechange.called);
+    });
+
+    it("does not dispatch readystatechange event if readyState is unsent", function () {
+        this.xhr.onreadystatechange = sinonStub();
+
+        callback(this.xhr);
+
+        assert.isFalse(this.xhr.onreadystatechange.called);
+    });
+
+    it("does not dispatch readystatechange event if readyState is opened but not sent", function () {
+        this.xhr.open("GET", "/");
+        this.xhr.onreadystatechange = sinonStub();
+
+        callback(this.xhr);
+
+        assert.isFalse(this.xhr.onreadystatechange.called);
+    });
+
+    it("does not dispatch readystatechange event if readyState is done", function () {
+        this.xhr.open("GET", "/");
+        this.xhr.send();
+        this.xhr.respond();
+
+        this.xhr.onreadystatechange = sinonStub();
+        callback(this.xhr);
+
+        assert.isFalse(this.xhr.onreadystatechange.called);
     });
 }
 
@@ -183,10 +293,19 @@ describe("FakeXMLHttpRequest", function () {
             this.xhr = new FakeXMLHttpRequest();
         });
 
-        it("property is set if we support standards CORS", function () {
+        it("should set the property if we support standards CORS", function () {
             assert.equals(sinonFakeXhr.xhr.supportsCORS, "withCredentials" in this.xhr);
         });
+    });
 
+    describe(".timeout", function () {
+        beforeEach(function () {
+            this.xhr = new FakeXMLHttpRequest();
+        });
+
+        it("should set the property if we support timeout", function () {
+            assert.equals(sinonFakeXhr.xhr.supportsTimeout, "timeout" in this.xhr);
+        });
     });
 
     describe(".open", function () {
@@ -1180,51 +1299,13 @@ describe("FakeXMLHttpRequest", function () {
             assert.isTrue(this.xhr.aborted);
         });
 
-        it("sets response to empty string", function () {
-            this.xhr.response = "Partial data";
-
-            this.xhr.abort();
-
-            assert.same(this.xhr.response, "");
-        });
-
-        it("sets responseText to empty string", function () {
-            this.xhr.responseText = "Partial data";
-
-            this.xhr.abort();
-
-            assert.same(this.xhr.responseText, "");
-        });
-
-        it("sets errorFlag to true", function () {
-            this.xhr.abort();
-
-            assert.isTrue(this.xhr.errorFlag);
-        });
-
-        it("nulls request headers", function () {
+        it("sets readyState to unsent if sent before", function () {
             this.xhr.open("GET", "/");
-            this.xhr.setRequestHeader("X-Test", "Sumptn");
+            this.xhr.send();
 
             this.xhr.abort();
 
-            assert.equals(this.xhr.requestHeaders, {});
-        });
-
-        it("does not have undefined response headers", function () {
-            this.xhr.open("GET", "/");
-
-            this.xhr.abort();
-
-            assert.defined(this.xhr.responseHeaders);
-        });
-
-        it("nulls response headers", function () {
-            this.xhr.open("GET", "/");
-
-            this.xhr.abort();
-
-            assert.equals(this.xhr.responseHeaders, {});
+            assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
         });
 
         it("keeps readyState unsent if called in unsent state", function () {
@@ -1270,74 +1351,8 @@ describe("FakeXMLHttpRequest", function () {
             assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
         });
 
-        it("signals onreadystatechange with state set to DONE if sent before", function () {
-            var readyState;
-            this.xhr.open("GET", "/");
-            this.xhr.send();
-
-            this.xhr.onreadystatechange = function () {
-                readyState = this.readyState;
-            };
-
-            this.xhr.abort();
-
-            assert.equals(readyState, FakeXMLHttpRequest.DONE);
-        });
-
-        it("sets send flag to false if sent before", function () {
-            this.xhr.open("GET", "/");
-            this.xhr.send();
-
-            this.xhr.abort();
-
-            assert.isFalse(this.xhr.sendFlag);
-        });
-
-        it("dispatches readystatechange event if sent before", function () {
-            this.xhr.open("GET", "/");
-            this.xhr.send();
-            this.xhr.onreadystatechange = sinonStub();
-
-            this.xhr.abort();
-
-            assert(this.xhr.onreadystatechange.called);
-        });
-
-        it("sets readyState to unsent if sent before", function () {
-            this.xhr.open("GET", "/");
-            this.xhr.send();
-
-            this.xhr.abort();
-
-            assert.equals(this.xhr.readyState, FakeXMLHttpRequest.UNSENT);
-        });
-
-        it("does not dispatch readystatechange event if readyState is unsent", function () {
-            this.xhr.onreadystatechange = sinonStub();
-
-            this.xhr.abort();
-
-            assert.isFalse(this.xhr.onreadystatechange.called);
-        });
-
-        it("does not dispatch readystatechange event if readyState is opened but not sent", function () {
-            this.xhr.open("GET", "/");
-            this.xhr.onreadystatechange = sinonStub();
-
-            this.xhr.abort();
-
-            assert.isFalse(this.xhr.onreadystatechange.called);
-        });
-
-        it("does not dispatch readystatechange event if readyState is done", function () {
-            this.xhr.open("GET", "/");
-            this.xhr.send();
-            this.xhr.respond();
-
-            this.xhr.onreadystatechange = sinonStub();
-            this.xhr.abort();
-
-            assert.isFalse(this.xhr.onreadystatechange.called);
+        assertRequestErrorSteps(function (xhr) {
+            xhr.abort();
         });
 
         assertEventOrdering("abort", 0, function (xhr) {
@@ -1412,6 +1427,112 @@ describe("FakeXMLHttpRequest", function () {
             xhr.error();
         });
     });
+
+    describe(".triggerTimeout", function () {
+        beforeEach(function () {
+            this.sandbox = sinonSandbox.create();
+            this.xhr = new FakeXMLHttpRequest();
+        });
+
+        afterEach(function () {
+            this.sandbox.restore();
+        });
+
+        it("sets timedOut to true", function () {
+            this.xhr.triggerTimeout();
+
+            assert.isTrue(this.xhr.timedOut);
+        });
+
+        it("does not get called without a fake timer", function (done) {
+            var xhr = this.xhr;
+
+            xhr.open("GET", "/");
+            xhr.timeout = 1;
+            xhr.triggerTimeout = sinonSpy();
+            xhr.send();
+
+            setTimeout(function () {
+                assert.isFalse(xhr.triggerTimeout.called);
+                done();
+            }, 2);
+        });
+
+        it("does not get called after being aborted", function () {
+            this.sandbox.useFakeTimers();
+
+            this.xhr.open("GET", "/");
+            this.xhr.timeout = 1;
+            this.xhr.triggerTimeout = sinonSpy();
+            this.xhr.send();
+            this.xhr.abort();
+
+            this.sandbox.clock.tick(1);
+            assert.isFalse(this.xhr.triggerTimeout.called);
+        });
+
+        it("does not get called after erroring", function () {
+            this.sandbox.useFakeTimers();
+
+            this.xhr.open("GET", "/");
+            this.xhr.timeout = 1;
+            this.xhr.triggerTimeout = sinonSpy();
+            this.xhr.send();
+            this.xhr.error();
+
+            this.sandbox.clock.tick(1);
+            assert.isFalse(this.xhr.triggerTimeout.called);
+        });
+
+        it("only gets called with fake timers", function () {
+            this.sandbox.useFakeTimers();
+            this.xhr.open("GET", "/");
+            this.xhr.timeout = 1;
+            this.xhr.triggerTimeout = sinonSpy();
+            this.xhr.send();
+
+            this.sandbox.clock.tick(1);
+            assert.isTrue(this.xhr.triggerTimeout.called);
+        });
+
+        it("only gets called once with fake timers", function () {
+            this.sandbox.useFakeTimers();
+            this.xhr.open("GET", "/");
+            this.xhr.timeout = 1;
+            this.xhr.triggerTimeout = sinonSpy();
+            this.xhr.send();
+
+            this.sandbox.clock.tick(2);
+            assert.isTrue(this.xhr.triggerTimeout.calledOnce);
+        });
+
+        it("allows timeout to be changed while fetching", function () {
+            this.sandbox.useFakeTimers();
+            this.xhr.open("GET", "/");
+            this.xhr.timeout = 2;
+            this.xhr.triggerTimeout = sinonSpy();
+            this.xhr.send();
+
+            this.sandbox.clock.tick(1);
+            assert.isFalse(this.xhr.triggerTimeout.calledOnce);
+
+            this.xhr.timeout = 3;
+            this.sandbox.clock.tick(1);
+            assert.isFalse(this.xhr.triggerTimeout.calledOnce);
+
+            this.sandbox.clock.tick(1);
+            assert.isTrue(this.xhr.triggerTimeout.calledOnce);
+        });
+
+        assertRequestErrorSteps(function (xhr) {
+            xhr.triggerTimeout();
+        });
+
+        assertEventOrdering("timeout", 0, function (xhr) {
+            xhr.triggerTimeout();
+        });
+    });
+
 
     describe(".response", function () {
         beforeEach(function () {
@@ -2197,6 +2318,51 @@ describe("FakeXMLHttpRequest", function () {
 
         assertEventOrdering("load", 100, function (xhr) {
             xhr.respond(200, {}, "");
+        });
+
+        describe("timeout", function () {
+            beforeEach(function () {
+                this.sandbox = sinonSandbox.create({ useFakeTimers: true });
+            });
+
+            afterEach(function () {
+                this.sandbox.restore();
+            });
+
+            it("triggers 'timeout' event when timed out", function (done) {
+                this.xhr.timeout = 1;
+
+                this.xhr.addEventListener("timeout", function () {
+                    assert(true);
+                    done();
+                });
+
+                this.xhr.send();
+
+                this.sandbox.clock.tick(1);
+            });
+
+            it("does not trigger 'load' event on timeout", function (done) {
+                var self = this;
+
+                this.xhr.timeout = 1;
+
+                this.xhr.addEventListener("load", function () {
+                    assert(false);
+                });
+
+                this.xhr.addEventListener("timeout", function () {
+                    assert(true);
+
+                    // restore the sandbox, so we can finish on next tick.
+                    self.sandbox.clock.restore();
+                    setTimeout(done, 0);
+                });
+
+                this.xhr.send();
+
+                this.sandbox.clock.tick(1);
+            });
         });
     });
 


### PR DESCRIPTION
This is my attempt to resolve: https://github.com/sinonjs/nise/issues/3.

I've added a `supportsTimeout` flag to `sinonXhr`. When calling `send`, there is a check to see if the fake timers exist and if so, to listen for ticks through `setInterval`.

When abort or timeout occur, they follow a lot of the same steps. Only difference really being that abort sets the readyState to UNSENT. For this reason, I've refactored a number of things around abort to keep their behavior the same. This includes refactoring some of the tests.

For more details, see `requestErrorSteps` and `assertRequestErrorSteps`.

Some things that you might find questionable are:

1) The way I'm checking to see if the timers are fake. I'm really just checking to see if the `clock` property exists on the methods I need. This is what `fakeServerWithClocks` does. I'd be happy to know if there's a more reliable method to test this. It doesn't seem like there is any global clock reference that can be tested against.

2) I think a lot of people might find this syntax to be very gross (https://github.com/Munksey/nise/blob/6c3afbb38a18cf5009a7baed47d9eee8d5f117fd/lib/fake-xhr/index.js#L405). Have no problems changing that to a less condensed if statement.

Let me know if you want me to annotate the PR with github comments. I've added some comments in the code that hopefully explains the rest of my reasoning.

