### PR TITLE
Set target on upload / download progress events

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -634,13 +634,13 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
 
     uploadProgress: function uploadProgress(progressEventRaw) {
         if (supportsProgress) {
-            this.upload.dispatchEvent(new sinonEvent.ProgressEvent("progress", progressEventRaw));
+            this.upload.dispatchEvent(new sinonEvent.ProgressEvent("progress", progressEventRaw, this.upload));
         }
     },
 
     downloadProgress: function downloadProgress(progressEventRaw) {
         if (supportsProgress) {
-            this.dispatchEvent(new sinonEvent.ProgressEvent("progress", progressEventRaw));
+            this.dispatchEvent(new sinonEvent.ProgressEvent("progress", progressEventRaw, this));
         }
     },
 

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -2325,10 +2325,13 @@ describe("FakeXMLHttpRequest", function () {
         });
 
         it("triggers (download) progress event when response is done", function (done) {
+            var xhr = this.xhr;
+
             this.xhr.addEventListener("progress", function (e) {
                 assert.equals(e.total, 100);
                 assert.equals(e.loaded, 20);
                 assert.isTrue(e.lengthComputable);
+                assert.same(e.target, xhr);
                 done();
             });
             this.xhr.downloadProgress({
@@ -2407,10 +2410,13 @@ describe("FakeXMLHttpRequest", function () {
         });
 
         it("calls .onprogress", function (done) {
+            var xhr = this.xhr;
+
             this.xhr.upload.onprogress = function (e) {
                 assert.equals(e.total, 100);
                 assert.equals(e.loaded, 20);
                 assert.isTrue(e.lengthComputable);
+                assert.equals(e.target, xhr.upload);
                 done();
             };
             this.xhr.uploadProgress({


### PR DESCRIPTION
The `uploadProgress` and `downloadProgress` functions were not correctly setting the event `target` property.

The download progress event is emitted from the `XMLHttpRequest` instance and the upload progress is emitted from `XMLHttpRequest.upload`, which is an `XMLHttpRequestUpload` object.