### PR TITLE
Add eslint plugin ie11

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,15 @@ globals:
   ArrayBuffer: false
   Uint8Array: false
 
+plugins:
+  - ie11
+
+rules:
+  ie11/no-collection-args: error
+  ie11/no-for-in-const: error
+  ie11/no-loop-func: warn
+  ie11/no-weak-collections: error
+
 overrides:
   files: '*.test.*'
   env:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,16 +4,18 @@ globals:
   ArrayBuffer: false
   Uint8Array: false
 
-env:
-  mocha: true
+overrides:
+  files: '*.test.*'
+  env:
+    mocha: true
 
-plugins:
-  - mocha
+  plugins:
+    - mocha
 
-rules:
-  mocha/no-exclusive-tests: error
-  mocha/no-identical-title: error
-  mocha/no-nested-tests: error
-  mocha/no-sibling-hooks: error
-  mocha/no-top-level-hooks: error
-  max-nested-callbacks: off
+  rules:
+    mocha/no-exclusive-tests: error
+    mocha/no-identical-title: error
+    mocha/no-nested-tests: error
+    mocha/no-sibling-hooks: error
+    mocha/no-top-level-hooks: error
+    max-nested-callbacks: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,19 @@
+extends: eslint-config-sinon
+
+globals:
+  ArrayBuffer: false
+  Uint8Array: false
+
+env:
+  mocha: true
+
+plugins:
+  - mocha
+
+rules:
+  mocha/no-exclusive-tests: error
+  mocha/no-identical-title: error
+  mocha/no-nested-tests: error
+  mocha/no-sibling-hooks: error
+  mocha/no-top-level-hooks: error
+  max-nested-callbacks: off

--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,6 +1580,15 @@
       "integrity": "sha1-6vcFIqGL8yUKuQMcfEPw2LD0Daw=",
       "dev": true
     },
+    "eslint-plugin-ie11": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
+      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+      "dev": true,
+      "requires": {
+        "requireindex": "1.1.0"
+      }
+    },
     "eslint-plugin-mocha": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.11.0.tgz",
@@ -4932,6 +4941,12 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "browserify": "^14.4.0",
     "eslint": "^4.5.0",
     "eslint-config-sinon": "^1.0.1",
+    "eslint-plugin-ie11": "1.0.0",
     "eslint-plugin-mocha": "^4.9.0",
     "husky": "^0.14.3",
     "jsdom": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -34,27 +34,6 @@
       "**/*.test.js"
     ]
   },
-  "eslintConfig": {
-    "extends": "eslint-config-sinon",
-    "globals": {
-      "ArrayBuffer": false,
-      "Uint8Array": false
-    },
-    "env": {
-      "mocha": true
-    },
-    "plugins": [
-      "mocha"
-    ],
-    "rules": {
-      "mocha/no-exclusive-tests": "error",
-      "mocha/no-identical-title": "error",
-      "mocha/no-nested-tests": "error",
-      "mocha/no-sibling-hooks": "error",
-      "mocha/no-top-level-hooks": "error",
-      "max-nested-callbacks": "off"
-    }
-  },
   "devDependencies": {
     "browserify": "^14.4.0",
     "eslint": "^4.5.0",


### PR DESCRIPTION
This PR does three things:

* extract eslint config to own file
* make sure the mocha env and rules are only applied to tests
* add `eslint-plugin-ie11`

When this is merged, the four main repos all have `eslint-plugin-ie11` protecting them.
