### PR TITLE
Add files entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
       "**/*.test.js"
     ]
   },
+  "files": [
+    "nise.js",
+    "lib/**/*[^test].js"
+  ],
   "devDependencies": {
     "browserify": "^14.4.0",
     "eslint": "^4.5.0",


### PR DESCRIPTION
This prevents unnecessary files to be published to the npm registry, saving bandwidth and speeding up installs for everyone.

#### Before

```text
du -h nise-1.2.0.tgz
272K	nise-1.2.0.tgz
```

#### After 

```text
du -h nise-1.2.0.tgz
240K	nise-1.2.0.tgz
```

With [~1.2M downloads/month](https://www.npmjs.com/package/nise), this will save `1,200,000 * 32,000 / 1024^3 = ~36GB/month`

#### How to verify

1. Check out this branch
1. `npm pack`
1. Expand the package
1. Observe that `nise.js` is in root, and that `lib/` has no tests in it, but still contains all the source files.