### PR TITLE
Issue 19 only add listener once

### DIFF
--- a/lib/event/event-target.js
+++ b/lib/event/event-target.js
@@ -1,12 +1,13 @@
 "use strict";
 
-var push = Array.prototype.push;
-
 var EventTarget = {
     addEventListener: function addEventListener(event, listener) {
         this.eventListeners = this.eventListeners || {};
         this.eventListeners[event] = this.eventListeners[event] || [];
-        push.call(this.eventListeners[event], listener);
+
+        if (this.eventListeners[event].indexOf(listener) === -1) {
+            this.eventListeners[event].push(listener);
+        }
     },
 
     removeEventListener: function removeEventListener(event, listener) {

--- a/lib/event/index.test.js
+++ b/lib/event/index.test.js
@@ -56,6 +56,18 @@ describe("EventTarget", function () {
         assert(listener.handleEvent.calledOnce);
     });
 
+    it("notifies event listener once if added twice", function () {
+        var listener = sinon.spy();
+        this.target.addEventListener("dummy", listener);
+        this.target.addEventListener("dummy", listener);
+
+        var event = new Event("dummy");
+        this.target.dispatchEvent(event);
+
+        assert.equals(listener.callCount, 1, "listener only called once");
+        assert(listener.calledWith(event));
+    });
+
     it("does not notify listeners of other events", function () {
         var listeners = [sinon.spy(), sinon.spy()];
         this.target.addEventListener("dummy", listeners[0]);


### PR DESCRIPTION
Fixes issue #19 such that successive calls to addEventListener with identical handlers are noop's as per

> If multiple identical EventListeners are registered on the same EventTarget with the same parameters, the duplicate instances are discarded. They do not cause the EventListener to be called twice, and they do not need to be removed manually with the removeEventListener method.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

Note that issue #19 also talks about support options such as once. I recommend this is split to a separate issue as this is a much more significant change.