### PR TITLE
Replace formatio with @sinonjs/formatio

### DIFF
--- a/lib/fake-server/format.js
+++ b/lib/fake-server/format.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var formatio = require("formatio");
+var formatio = require("@sinonjs/formatio");
 
 var formatter = formatio.configure({
     quoteStrings: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,14 @@
         }
       }
     },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -1276,6 +1284,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "xmldom": "^0.1.27"
   },
   "dependencies": {
-    "formatio": "^1.2.0",
+    "@sinonjs/formatio": "^2.0.0",
     "just-extend": "^1.1.27",
     "lolex": "^2.3.2",
     "path-to-regexp": "^1.7.0",


### PR DESCRIPTION
#### Purpose (TL;DR)

As agreed in sinonjs/sinon#1650, this pull request replaces the use of `formatio@1.2.0` with `@sinonjs/formatio@2.0.0`, which is now on npm.


#### How to verify - mandatory

This PR should preferably be verified using a project that consumes `nise`.

1. Check out this branch
2. `npm install`
3. `npm link`
4. Switch to your consuming project (this could be `sinon` I guess)
5. `npm link sinon`
6. Run your tests
