### PR TITLE
Support options argument for EventTarget interface methods, fixes #34

### DIFF
--- a/lib/event/event-target.js
+++ b/lib/event/event-target.js
@@ -1,32 +1,98 @@
 "use strict";
 
+function flattenOptions(options) {
+    if (options !== Object(options)) {
+        return {
+            capture: Boolean(options),
+            once: false,
+            passive: false
+        };
+    }
+    return {
+        capture: Boolean(options.capture),
+        once: Boolean(options.once),
+        passive: Boolean(options.passive)
+    };
+}
+function not(fn) {
+    return function () {
+        return !fn.apply(this, arguments);
+    };
+}
+function hasListenerFilter(listener, capture) {
+    return function (listenerSpec) {
+        return listenerSpec.capture === capture
+            && listenerSpec.listener === listener;
+    };
+}
+
 var EventTarget = {
-    addEventListener: function addEventListener(event, listener) {
-        this.eventListeners = this.eventListeners || {};
-        this.eventListeners[event] = this.eventListeners[event] || [];
+    // https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener
+    addEventListener: function addEventListener(event, listener, providedOptions) {
+        // 3. Let capture, passive, and once be the result of flattening more options.
+        // Flatten property before executing step 2,
+        // feture detection is usually based on registering handler with options object,
+        // that has getter defined
+        // addEventListener("load", () => {}, {
+        //    get once() { supportsOnce = true; }
+        // });
+        var options = flattenOptions(providedOptions);
 
-        if (this.eventListeners[event].indexOf(listener) === -1) {
-            this.eventListeners[event].push(listener);
-        }
-    },
-
-    removeEventListener: function removeEventListener(event, listener) {
-        var listeners = this.eventListeners && this.eventListeners[event] || [];
-        var index = listeners.indexOf(listener);
-
-        if (index === -1) {
+        // 2. If callback is null, then return.
+        if (listener == null) {
             return;
         }
 
-        listeners.splice(index, 1);
+        this.eventListeners = this.eventListeners || {};
+        this.eventListeners[event] = this.eventListeners[event] || [];
+
+        // 4. If context object’s associated list of event listener
+        //    does not contain an event listener whose type is type,
+        //    callback is callback, and capture is capture, then append
+        //    a new event listener to it, whose type is type, callback is
+        //    callback, capture is capture, passive is passive, and once is once.
+        if (!this.eventListeners[event].some(hasListenerFilter(listener, options.capture))) {
+            this.eventListeners[event].push({
+                listener: listener,
+                capture: options.capture,
+                once: options.once
+            });
+        }
+    },
+
+    // https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener
+    removeEventListener: function removeEventListener(event, listener, providedOptions) {
+        if (!this.eventListeners || !this.eventListeners[event]) {
+            return;
+        }
+
+        // 2. Let capture be the result of flattening options.
+        var options = flattenOptions(providedOptions);
+
+        // 3. If there is an event listener in the associated list of
+        //    event listeners whose type is type, callback is callback,
+        //    and capture is capture, then set that event listener’s
+        //    removed to true and remove it from the associated list of event listeners.
+        this.eventListeners[event] = this.eventListeners[event]
+            .filter(not(hasListenerFilter(listener, options.capture)));
     },
 
     dispatchEvent: function dispatchEvent(event) {
+        if (!this.eventListeners || !this.eventListeners[event.type]) {
+            return Boolean(event.defaultPrevented);
+        }
+
         var self = this;
         var type = event.type;
-        var listeners = self.eventListeners && self.eventListeners[type] || [];
+        var listeners = self.eventListeners[type];
 
-        listeners.forEach(function (listener) {
+        // Remove listeners, that should be dispatched once
+        // before running dispatch loop to avoid nested dispatch issues
+        self.eventListeners[type] = listeners.filter(function (listenerSpec) {
+            return !listenerSpec.once;
+        });
+        listeners.forEach(function (listenerSpec) {
+            var listener = listenerSpec.listener;
             if (typeof listener === "function") {
                 listener.call(self, event);
             } else {
@@ -34,7 +100,7 @@ var EventTarget = {
             }
         });
 
-        return !!event.defaultPrevented;
+        return Boolean(event.defaultPrevented);
     }
 };
 

--- a/lib/event/index.test.js
+++ b/lib/event/index.test.js
@@ -56,7 +56,7 @@ describe("EventTarget", function () {
         assert(listener.handleEvent.calledOnce);
     });
 
-    it("notifies event listener once if added twice", function () {
+    it("notifies event listener once if added twice without useCapture flag", function () {
         var listener = sinon.spy();
         this.target.addEventListener("dummy", listener);
         this.target.addEventListener("dummy", listener);
@@ -66,6 +66,90 @@ describe("EventTarget", function () {
 
         assert.equals(listener.callCount, 1, "listener only called once");
         assert(listener.calledWith(event));
+    });
+
+    it("notifies event listener twice if added with different capture flag values, ignores other flags", function () {
+        var listener = sinon.spy();
+        this.target.addEventListener("dummy", listener, { capture: false });
+        this.target.addEventListener("dummy", listener, { capture: true });
+        this.target.addEventListener("dummy", listener, { capture: true, once: true });
+        this.target.addEventListener("dummy", listener, { capture: true, passive: true });
+
+        var event = new Event("dummy");
+        this.target.dispatchEvent(event);
+
+        assert.equals(listener.callCount, 2, "listener only called twice");
+        assert(listener.calledWith(event));
+    });
+
+    it("uses options of first listener registration", function () {
+        var listener = sinon.spy();
+        this.target.addEventListener("dummy", listener, { capture: false, once: false });
+        // this registration should be ignored
+        this.target.addEventListener("dummy", listener, { capture: false, once: true });
+
+        var firstEvent = new Event("dummy");
+        this.target.dispatchEvent(firstEvent);
+
+        assert.equals(listener.callCount, 1, "listener only called once");
+        assert(listener.lastCall.calledWith(sinon.match.same(firstEvent)));
+
+        var secondEvent = new Event("dummy");
+        this.target.dispatchEvent(secondEvent);
+
+        assert.equals(listener.callCount, 2, "listener only called twice");
+        assert(listener.lastCall.calledWith(sinon.match.same(secondEvent)));
+    });
+
+    it("feature detection for 'once' flag works", function () {
+        var onceSupported = false;
+
+        this.target.addEventListener(
+            "dummy",
+            null,
+            Object.defineProperty({}, "once", { get: function () { onceSupported = true; } })
+        );
+
+        assert(onceSupported);
+    });
+
+    it("supports registering event handler with 'once' flag", function () {
+        var listener = sinon.spy();
+        this.target.addEventListener("dummy", listener, { once: true });
+
+        var firstEvent = new Event("dummy");
+        this.target.dispatchEvent(firstEvent);
+
+        assert.equals(listener.callCount, 1, "listener only called once");
+        assert(listener.calledWith(sinon.match.same(firstEvent)));
+
+        var secondEvent = new Event("dummy");
+        this.target.dispatchEvent(secondEvent);
+
+        assert.equals(listener.callCount, 1, "listener was not called second time");
+        assert(!listener.calledWith(sinon.match.same(secondEvent)));
+    });
+
+    it("supports re-registering event handler with 'once' flag after dispatch", function () {
+        var listener = sinon.spy();
+        this.target.addEventListener("dummy", listener, { once: true });
+
+        var firstEvent = new Event("dummy");
+        this.target.dispatchEvent(firstEvent);
+
+        assert.equals(listener.callCount, 1, "listener only called once");
+        assert(listener.calledWith(sinon.match.same(firstEvent)));
+
+        var secondEvent = new Event("dummy");
+        this.target.dispatchEvent(secondEvent);
+
+        this.target.addEventListener("dummy", listener, { once: true });
+
+        var thirdEvent = new Event("dummy");
+        this.target.dispatchEvent(thirdEvent);
+
+        assert.equals(listener.callCount, 2, "listener called second time after re-registration");
+        assert(listener.calledWith(sinon.match.same(thirdEvent)));
     });
 
     it("does not notify listeners of other events", function () {


### PR DESCRIPTION
Add support for options argument

This PR also fixes handler registration with or without capture flag. Even though useCapture flag is not relevant for XHR object, browsers follow spec in this respect and allow to register 2 handlers if they have different capture flags: see last step in https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener