### PR TITLE
Ignore header name case in setRequestHeader, fixes #23

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -448,12 +448,13 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
             checkUnsafeHeaders = this.unsafeHeadersEnabled();
         }
 
-        if (checkUnsafeHeaders && (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header))) {
+        if (checkUnsafeHeaders && (getHeader(unsafeHeaders, header) !== null || /^(Sec-|Proxy-)/i.test(header))) {
             throw new Error("Refused to set unsafe header \"" + header + "\"");
         }
 
-        if (this.requestHeaders[header]) {
-            this.requestHeaders[header] += "," + value;
+        var existingHeader = getHeader(this.requestHeaders, header);
+        if (existingHeader) {
+            this.requestHeaders[existingHeader] += "," + value;
         } else {
             this.requestHeaders[header] = value;
         }

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -512,6 +512,14 @@ describe("FakeXMLHttpRequest", function () {
             });
         });
 
+        it("applies unsafe headers check with header name case ignored", function () {
+            var xhr = this.xhr;
+
+            assert.exception(function () {
+                xhr.setRequestHeader("accept-CHARSET", "");
+            });
+        });
+
         it("allows unsafe headers when fake server unsafeHeadersEnabled option is turned off", function () {
             var server = sinon.fakeServer.create({
                 unsafeHeadersEnabled: false
@@ -612,6 +620,13 @@ describe("FakeXMLHttpRequest", function () {
         it("appends same-named header values", function () {
             this.xhr.setRequestHeader("X-Fake", "Oh");
             this.xhr.setRequestHeader("X-Fake", "yeah!");
+
+            assert.equals(this.xhr.requestHeaders, { "X-Fake": "Oh,yeah!" });
+        });
+
+        it("ignores case when appending header values", function () {
+            this.xhr.setRequestHeader("X-Fake", "Oh");
+            this.xhr.setRequestHeader("x-FAKE", "yeah!");
 
             assert.equals(this.xhr.requestHeaders, { "X-Fake": "Oh,yeah!" });
         });


### PR DESCRIPTION
Reused existing helper function that iterates over all headers and finds header name that was already set with case ignored.

Not that fast as it could be, but less changes