### PR TITLE
improve correctness of .setRequestHeader

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -465,7 +465,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         }
 
         value = normalizeHeaderValue(value);
-      
+
         var existingHeader = getHeader(this.requestHeaders, header);
         if (existingHeader) {
             this.requestHeaders[existingHeader] += ", " + value;

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -39,8 +39,11 @@ sinonXhr.supportsTimeout =
 sinonXhr.supportsCORS = isReactNative ||
     (sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest()));
 
+// Ref: https://fetch.spec.whatwg.org/#forbidden-header-name
 var unsafeHeaders = {
     "Accept-Charset": true,
+    "Access-Control-Request-Headers": true,
+    "Access-Control-Request-Method": true,
     "Accept-Encoding": true,
     "Connection": true,
     "Content-Length": true,
@@ -48,9 +51,11 @@ var unsafeHeaders = {
     "Cookie2": true,
     "Content-Transfer-Encoding": true,
     "Date": true,
+    "DNT": true,
     "Expect": true,
     "Host": true,
     "Keep-Alive": true,
+    "Origin": true,
     "Referer": true,
     "TE": true,
     "Trailer": true,
@@ -117,6 +122,12 @@ function verifyState(xhr) {
     if (xhr.sendFlag) {
         throw new Error("INVALID_STATE_ERR");
     }
+}
+
+function normalizeHeaderValue(value) {
+    // Ref: https://fetch.spec.whatwg.org/#http-whitespace-bytes
+    /*eslint no-control-regex: "off"*/
+    return value.replace(/^[\x09\x0A\x0D\x20]+|[\x09\x0A\x0D\x20]+$/g, "");
 }
 
 function getHeader(headers, header) {
@@ -440,6 +451,7 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
         this.dispatchEvent(readyStateChangeEvent);
     },
 
+    // Ref https://xhr.spec.whatwg.org/#the-setrequestheader()-method
     setRequestHeader: function setRequestHeader(header, value) {
         verifyState(this);
 
@@ -452,8 +464,17 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
             throw new Error("Refused to set unsafe header \"" + header + "\"");
         }
 
+        for (var key in this.requestHeaders) {
+            if (this.requestHeaders.hasOwnProperty(key) && header.toLowerCase() === key.toLowerCase()) {
+                header = key;
+                break;
+            }
+        }
+
+        value = normalizeHeaderValue(value);
+
         if (this.requestHeaders[header]) {
-            this.requestHeaders[header] += "," + value;
+            this.requestHeaders[header] += ", " + value;
         } else {
             this.requestHeaders[header] = value;
         }

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1,18 +1,6 @@
 "use strict";
 
 var referee = require("@sinonjs/referee");
-
-referee.format = function (object) {
-
-    var result = String(object);
-
-    if (result === "[object Object]") {
-        result = JSON.stringify(object);
-    }
-
-    return result;
-};
-
 var proxyquire = require("proxyquire");
 var sinonStub = require("sinon").stub;
 var sinonSpy = require("sinon").spy;

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1,6 +1,18 @@
 "use strict";
 
 var referee = require("referee");
+
+referee.format = function (object) {
+
+    var result = String(object);
+
+    if (result === "[object Object]") {
+        result = JSON.stringify(object);
+    }
+
+    return result;
+};
+
 var proxyquire = require("proxyquire");
 var sinonStub = require("sinon").stub;
 var sinonSpy = require("sinon").spy;
@@ -406,6 +418,32 @@ describe("FakeXMLHttpRequest", function () {
     });
 
     describe(".setRequestHeader", function () {
+
+        var unsafeHeaders = [
+            "Accept-Charset",
+            "Access-Control-Request-Headers",
+            "Access-Control-Request-Method",
+            "Accept-Encoding",
+            "Connection",
+            "Content-Length",
+            "Cookie",
+            "Cookie2",
+            "Content-Transfer-Encoding",
+            "Date",
+            "DNT",
+            "Expect",
+            "Host",
+            "Keep-Alive",
+            "Origin",
+            "Referer",
+            "TE",
+            "Trailer",
+            "Transfer-Encoding",
+            "Upgrade",
+            "User-Agent",
+            "Via"
+        ];
+
         beforeEach(function () {
             this.xhr = new FakeXMLHttpRequest();
             this.xhr.open("GET", "/");
@@ -431,76 +469,10 @@ describe("FakeXMLHttpRequest", function () {
         it("disallows unsafe headers by default", function () {
             var xhr = this.xhr;
 
-            assert.exception(function () {
-                xhr.setRequestHeader("Accept-Charset", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Accept-Encoding", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Connection", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Content-Length", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Cookie", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Cookie2", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Content-Transfer-Encoding", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Date", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Expect", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Host", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Keep-Alive", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Referer", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("TE", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Trailer", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Transfer-Encoding", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Upgrade", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("User-Agent", "");
-            });
-
-            assert.exception(function () {
-                xhr.setRequestHeader("Via", "");
+            unsafeHeaders.forEach(function (headerName) {
+                assert.exception(function () {
+                    xhr.setRequestHeader(headerName, "");
+                });
             });
 
             assert.exception(function () {
@@ -520,76 +492,10 @@ describe("FakeXMLHttpRequest", function () {
             var xhr = new sinon.FakeXMLHttpRequest();
             xhr.open("GET", "/");
 
-            refute.exception(function () {
-                xhr.setRequestHeader("Accept-Charset", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Accept-Encoding", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Connection", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Content-Length", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Cookie", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Cookie2", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Content-Transfer-Encoding", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Date", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Expect", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Host", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Keep-Alive", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Referer", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("TE", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Trailer", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Transfer-Encoding", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Upgrade", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("User-Agent", "");
-            });
-
-            refute.exception(function () {
-                xhr.setRequestHeader("Via", "");
+            unsafeHeaders.forEach(function (headerName) {
+                refute.exception(function () {
+                    xhr.setRequestHeader(headerName, "");
+                });
             });
 
             refute.exception(function () {
@@ -613,8 +519,63 @@ describe("FakeXMLHttpRequest", function () {
             this.xhr.setRequestHeader("X-Fake", "Oh");
             this.xhr.setRequestHeader("X-Fake", "yeah!");
 
-            assert.equals(this.xhr.requestHeaders, { "X-Fake": "Oh,yeah!" });
+            assert.equals(this.xhr.requestHeaders, { "X-Fake": "Oh, yeah!" });
         });
+
+        it("appends same-named header values when casing differs in header name", function () {
+            this.xhr.setRequestHeader("X-Fake", "Oh");
+            this.xhr.setRequestHeader("x-fake", "yeah!");
+
+            assert.equals(this.xhr.requestHeaders, { "X-Fake": "Oh, yeah!" });
+        });
+
+        describe("value normalization", function () {
+            var httpWhitespaceBytes = ["\x09" + "\x0A" + "\x0D" + "\x20"];
+
+            function runTest(input, expected) {
+                var xhr = new FakeXMLHttpRequest();
+                xhr.open("GET", "/");
+                xhr.setRequestHeader("X-Fake", input);
+                assert.equals(xhr.requestHeaders, {"X-Fake": expected});
+            }
+
+            it("removes HTTP whitespace bytes prefixing the value", function () {
+                httpWhitespaceBytes.forEach(function (value) {
+                    runTest(value + "something", "something");
+                });
+
+                httpWhitespaceBytes.forEach(function (value) {
+                    runTest(value + value + "something", "something");
+                });
+
+                runTest(httpWhitespaceBytes.join() + "something", "something");
+            });
+
+            it("removes HTTP whitespace bytes sufficing the value", function () {
+                httpWhitespaceBytes.forEach(function (value) {
+                    runTest(value + "something", "something");
+                });
+
+                httpWhitespaceBytes.forEach(function (value) {
+                    runTest("something" + value + value, "something");
+                });
+
+                runTest("something" + httpWhitespaceBytes.join(), "something");
+            });
+
+            it("leaves HTTP whitespace bytes in the middle of value", function () {
+                httpWhitespaceBytes.forEach(function (value) {
+                    runTest("something" + value + "else", "something" + value + "else");
+                });
+
+                runTest(
+                    "something" + httpWhitespaceBytes.join() + "else",
+                    "something" + httpWhitespaceBytes.join() + "else"
+                );
+            });
+
+        });
+
     });
 
     describe(".send", function () {


### PR DESCRIPTION
- separate multiple values for same header with ", " instead of ","
- normalize header values to trim http whitespace charactors
- add missing forbidden header values
- combine header values for header names that are a lower case match for already set headers

ref: https://xhr.spec.whatwg.org/#the-setrequestheader()-method