### PR TITLE
Replace referee with @sinonjs/referee

### DIFF
--- a/lib/configure-logger/index.test.js
+++ b/lib/configure-logger/index.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var assert = require("referee").assert;
-var refute = require("referee").refute;
+var assert = require("@sinonjs/referee").assert;
+var refute = require("@sinonjs/referee").refute;
 var sandbox = require("sinon").sandbox;
 
 var configureLogError = require("./index");

--- a/lib/event/index.test.js
+++ b/lib/event/index.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 var extend = require("just-extend");
 var sinon = require("sinon");
 

--- a/lib/fake-server/fake-server-with-clock.test.js
+++ b/lib/fake-server/fake-server-with-clock.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var DOMParser = require("xmldom").DOMParser;
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var setupDOM = require("jsdom-global");
 var sinon = require("sinon");
 

--- a/lib/fake-server/format.test.js
+++ b/lib/fake-server/format.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 var format = require("./format");
 
 describe("util/core/format", function () {

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var DOMParser = require("xmldom").DOMParser;
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var setupDOM = require("jsdom-global");
 var sinon = require("sinon");
 var sinonFakeServer = require("./index");

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var referee = require("referee");
+var referee = require("@sinonjs/referee");
 var proxyquire = require("proxyquire");
 var sinonStub = require("sinon").stub;
 var sinonSpy = require("sinon").spy;

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("referee").assert;
+var assert = require("@sinonjs/referee").assert;
 var api = require("./index");
 
 describe("api", function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,21 @@
         "samsam": "1.3.0"
       }
     },
+    "@sinonjs/referee": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.0.0.tgz",
+      "integrity": "sha512-inOh34xub2/0diAWHrAZuakWe1NhtR2DkOXoS/3N7ooddxRZCxTH3TWyI4q7GatFGh+vmPCdWhws/1fziVdPhA==",
+      "dev": true,
+      "requires": {
+        "array.from": "1.0.3",
+        "bane": "1.1.2",
+        "es6-promise": "4.2.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isarguments": "3.1.0",
+        "object-assign": "4.1.1",
+        "samsam": "1.3.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -168,6 +183,16 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
+    },
+    "array.from": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.from/-/array.from-1.0.3.tgz",
+      "integrity": "sha1-y1hqrZIGfzQSKfQeDtZDKB26Vrc=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -855,6 +880,16 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -997,6 +1032,36 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1262,6 +1327,12 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1649,6 +1720,12 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
@@ -1657,6 +1734,12 @@
       "requires": {
         "ci-info": "1.1.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1700,10 +1783,25 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -1908,6 +2006,18 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.memoize": {
@@ -3755,6 +3865,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4062,25 +4178,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
-      }
-    },
-    "referee": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referee/-/referee-1.2.0.tgz",
-      "integrity": "sha1-eneb7llVx4r/fYjAFhxaH0VFjJA=",
-      "dev": true,
-      "requires": {
-        "bane": "1.1.2",
-        "lodash": "3.10.1",
-        "samsam": "1.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test": "mocha 'lib/**/*.test.js'",
     "test:coverage": "nyc --reporter=lcov --reporter=text --all npm test -- --reporter dot",
     "precommit": "npm run lint -- --fix && npm run test",
-    "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "prepush": "npm run lint && npm run test"
   },
   "author": "",
@@ -41,6 +40,7 @@
     "lib/**/*.js"
   ],
   "devDependencies": {
+    "@sinonjs/referee": "^2.0.0",
     "browserify": "^16.0.0",
     "eslint": "^4.17.0",
     "eslint-config-sinon": "^1.0.1",
@@ -52,7 +52,6 @@
     "mocha": "^5.0.0",
     "nyc": "^11.4.1",
     "proxyquire": "^1.8.0",
-    "referee": "^1.2.0",
     "sinon": "^4.2.2",
     "xmldom": "^0.1.27"
   },


### PR DESCRIPTION
This PR replaces the `referee` dependency with `@sinonjs/referee`.

#### How to verify - mandatory

1. Observe that all tests pass on Travis
2. ?
3. Win!