### PR TITLE
Pass in the correct arguments to the native addEventListener when defaking

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -193,7 +193,10 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
         Object.keys(fakeXhr.eventListeners).forEach(function (event) {
             /*eslint-disable no-loop-func*/
             fakeXhr.eventListeners[event].forEach(function (handler) {
-                xhr.addEventListener(event, handler);
+                xhr.addEventListener(event, handler.listener, {
+                    capture: handler.capture,
+                    once: handler.once
+                });
             });
             /*eslint-enable no-loop-func*/
         });

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1996,20 +1996,19 @@ describe("FakeXMLHttpRequest", function () {
                 }
             });
 
-        it("correctly calls events on the fakeXhr",
+        it("calls on events as well as events added via addEventListener on the fakeXhr",
             function () {
-                try { // eslint-disable-line no-restricted-syntax
-                    FakeXMLHttpRequest.useFilters = true;
-                    var spy = sinonSpy();
-                    fakeXhr.addEventListener("abort", spy);
-                    fakeXhr.onabort = spy;
-                    fakeXhr.open("GET", "http://example.com", true);
-                    fakeXhr.send();
-                    fakeXhr.abort();
-                    assert.equals(spy.callCount, 2);
-                } finally {
-                    FakeXMLHttpRequest.useFilters = false;
-                }
+                var abortSpy = sinonSpy();
+                var onabortSpy = sinonSpy();
+
+                fakeXhr.addEventListener("abort", abortSpy);
+                fakeXhr.onabort = onabortSpy;
+                FakeXMLHttpRequest.defake(fakeXhr, ["GET", "http://example.com", true]);
+                fakeXhr.send();
+                fakeXhr.abort();
+
+                assert(abortSpy.calledOnce);
+                assert(onabortSpy.calledOnce);
             });
     });
 

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1995,6 +1995,22 @@ describe("FakeXMLHttpRequest", function () {
                     FakeXMLHttpRequest.useFilters = false;
                 }
             });
+
+        it("correctly calls events on the fakeXhr",
+            function () {
+                try { // eslint-disable-line no-restricted-syntax
+                    FakeXMLHttpRequest.useFilters = true;
+                    var spy = sinonSpy();
+                    fakeXhr.addEventListener("abort", spy);
+                    fakeXhr.onabort = spy;
+                    fakeXhr.open("GET", "http://example.com", true);
+                    fakeXhr.send();
+                    fakeXhr.abort();
+                    assert.equals(spy.callCount, 2);
+                } finally {
+                    FakeXMLHttpRequest.useFilters = false;
+                }
+            });
     });
 
     describe("defaked XHR filters", function () {


### PR DESCRIPTION
I ran into an issue where none of the events on the fakeXhr were being called when it was defaked (onload, onabort, etc) and it looks like the issue was that the correct arguments weren't passed into `addEventListener` on the native XHR instance.

Before: 

```js
xhr.addEventListener(type, handler); // handler => { listener, once, capture }
```

After:

```js
xhr.addEventListener(type, listener, { once, capture });
```

The Spec:

```js
target.addEventListener(type, listener[, options]);
```