### PR TITLE
Pass responseType for defaked XHR

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -165,7 +165,6 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
     [
         "open",
         "setRequestHeader",
-        "send",
         "abort",
         "getResponseHeader",
         "getAllResponseHeaders",
@@ -177,6 +176,11 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
             return apply(xhr, method, arguments);
         };
     });
+
+    fakeXhr.send = function () {
+        xhr.responseType = fakeXhr.responseType;
+        return apply(xhr, "send", arguments);
+    };
 
     var copyAttrs = function (args) {
         args.forEach(function (attr) {
@@ -190,9 +194,15 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
             copyAttrs(["status", "statusText"]);
         }
         if (xhr.readyState >= FakeXMLHttpRequest.LOADING) {
-            copyAttrs(["responseText", "response"]);
+            copyAttrs(["response"]);
+            if (xhr.responseType === "" || xhr.responseType === "text") {
+                copyAttrs(["responseText"]);
+            }
         }
-        if (xhr.readyState === FakeXMLHttpRequest.DONE) {
+        if (
+            xhr.readyState === FakeXMLHttpRequest.DONE &&
+            (xhr.responseType === "" || xhr.responseType === "document")
+        ) {
             copyAttrs(["responseXML"]);
         }
         if (fakeXhr.onreadystatechange) {

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1951,6 +1951,24 @@ describe("FakeXMLHttpRequest", function () {
                 assert(abortSpy.calledOnce);
                 assert(onabortSpy.calledOnce);
             });
+
+        it("passes responseType to working XHR object",
+            function () {
+                var workingXHRInstance;
+                var workingXHROverride = function () {
+                    workingXHRInstance = this;
+                    this.responseType = "";
+                    this.open = function () {};
+                    this.send = function () {};
+                };
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    FakeXMLHttpRequest.defake(fakeXhr, []);
+                    fakeXhr.responseType = "arraybuffer";
+                    fakeXhr.send();
+                    assert.equals(workingXHRInstance.responseType, "arraybuffer");
+                });
+            });
     });
 
     describe("defaked XHR filters", function () {


### PR DESCRIPTION
Now `responseType` is not passed to original XHR object after calling `defake`. This causes unexpected type of `xhr.response` when sending defaked requests with `responseType = "arraybuffer"` (response is a string instead of ArrayBuffer).