### PR TITLE
Throw an explicit error if the header value is not a string

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -471,6 +471,9 @@ extend(FakeXMLHttpRequest.prototype, sinonEvent.EventTarget, {
 
     // Ref https://xhr.spec.whatwg.org/#the-setrequestheader()-method
     setRequestHeader: function setRequestHeader(header, value) {
+        if (typeof value !== "string") {
+            throw new TypeError("By RFC7230, section 3.2.4, header values should be strings. Got " + typeof value);
+        }
         verifyState(this);
 
         var checkUnsafeHeaders = true;

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -512,6 +512,12 @@ describe("FakeXMLHttpRequest", function () {
             assert.equals(this.xhr.requestHeaders, { "X-Fake": "Yeah!" });
         });
 
+        it("throw on receiving non-string values", function () {
+            assert.exception(function () {
+                this.xhr.setRequestHeader("X-Version", 1.0);
+            }, "TypeError");
+        });
+
         it("appends same-named header values", function () {
             this.xhr.setRequestHeader("X-Fake", "Oh");
             this.xhr.setRequestHeader("X-Fake", "yeah!");


### PR DESCRIPTION
According to [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) (last paragraph), http fields have used to be text and new headers should continue to do so, restricting the values to consist of US-ASCII octets.

This test is not so strict, but we avoid a whole range of errors by just checking if the value is a string.

 Ref #51 and #48