### PR TITLE
Fix issue where no parsererror is returned on invalid XML

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -342,8 +342,11 @@ FakeXMLHttpRequest.parseXML = function parseXML(text) {
         try {
             if (typeof DOMParser !== "undefined") {
                 var parser = new DOMParser();
-                var parsererrorNS = parser.parseFromString("INVALID", "text/xml")
-                    .getElementsByTagName("parsererror")[0].namespaceURI;
+                var parsererrors = parser
+                    .parseFromString("INVALID", "text/xml")
+                    .getElementsByTagName("parsererror");
+                var parsererrorNS = parsererrors.length
+                    ? parsererrors[0].namespaceURI : "";
                 var result = parser.parseFromString(text, "text/xml");
                 return result.getElementsByTagNameNS(parsererrorNS, "parsererror").length
                     ? null : result;


### PR DESCRIPTION
This fixes #54 but would introduce the situation where using slightly broken DOMParsers like `xmldom` would make this test: https://github.com/sinonjs/nise/blob/929b9fe66b0c457b43094b99a8922c4928080be0/lib/fake-xhr/index.test.js#L1700-L1708 fail as it would return a document instead of `null`.