### PR TITLE
Upgrade just-extend dependency due to missing license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,9 +2023,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
     },
     "labeled-stream-splicer": {
       "version": "2.0.0",
@@ -2307,7 +2307,7 @@
       "dev": true,
       "requires": {
         "formatio": "^1.2.0",
-        "just-extend": "^1.1.26",
+        "just-extend": "^3.0.0",
         "lolex": "^1.6.0",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@sinonjs/formatio": "^2.0.0",
-    "just-extend": "^1.1.27",
+    "just-extend": "^3.0.0",
     "lolex": "^2.3.2",
     "path-to-regexp": "^1.7.0",
     "text-encoding": "^0.6.4"


### PR DESCRIPTION
Upgrade just-exend@1.1.27 to v3.0.0 because latest version contains LICENSE file which is mandatory for MIT license