### PR TITLE
Prevent InvalidAccessError when using a synchronous XHR in browser

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -178,7 +178,10 @@ FakeXMLHttpRequest.defake = function defake(fakeXhr, xhrArgs) {
     });
 
     fakeXhr.send = function () {
-        xhr.responseType = fakeXhr.responseType;
+        // Ref: https://xhr.spec.whatwg.org/#the-responsetype-attribute
+        if (xhr.responseType !== fakeXhr.responseType) {
+            xhr.responseType = fakeXhr.responseType;
+        }
         return apply(xhr, "send", arguments);
     };
 

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1990,6 +1990,27 @@ describe("FakeXMLHttpRequest", function () {
                     assert.equals(workingXHRInstance.responseType, "arraybuffer");
                 });
             });
+
+        it("issue 61 - InvalidAccessError on synchronous XHR in browser",
+            function () {
+                var spy;
+                var workingXHROverride = function () {
+                    this.open = function () {};
+                    this.send = function () {};
+                    Object.defineProperty( this, "responseType", {
+                        get: function () { return ""; },
+                        set: function () {},
+                        configurable: true
+                    });
+                    spy = sinonSpy(this, "responseType", ["set"]);
+                };
+
+                runWithWorkingXHROveride(workingXHROverride, function () {
+                    FakeXMLHttpRequest.defake(fakeXhr, ["GET", "http://example.com", false]);
+                    fakeXhr.send();
+                    assert(spy.set.notCalled);
+                });
+            });
     });
 
     describe("defaked XHR filters", function () {


### PR DESCRIPTION
Changing the `responseType` only when necessary, as setting it too liberally can cause an exception, like when using a synchronous request in a browser context.
Issue #61 