### PR TITLE
Update just-extend to ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3429,9 +3429,9 @@
       }
     },
     "just-extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
     "kind-of": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@sinonjs/formatio": "^3.1.0",
-    "just-extend": "^4.0.0",
+    "just-extend": "^4.0.2",
     "lolex": "^2.3.2",
     "path-to-regexp": "^1.7.0",
     "text-encoding": "^0.6.4"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@sinonjs/formatio": "^3.1.0",
-    "just-extend": "^3.0.0",
+    "just-extend": "^4.0.0",
     "lolex": "^2.3.2",
     "path-to-regexp": "^1.7.0",
     "text-encoding": "^0.6.4"


### PR DESCRIPTION
just-extend < 4.0.0 has a DoS vulnerability: https://snyk.io/vuln/SNYK-JS-JUSTEXTEND-72674