### PR TITLE
Removed deprecated warnings from tests

### DIFF
--- a/lib/fake-server/fake-server-with-clock.test.js
+++ b/lib/fake-server/fake-server-with-clock.test.js
@@ -40,7 +40,7 @@ describe("fakeServerWithClock", function () {
         });
 
         it("calls 'super' when adding requests", function () {
-            var sandbox = sinon.sandbox.create();
+            var sandbox = sinon.createSandbox();
             var addRequest = sandbox.stub(sinonFakeServer, "addRequest");
             var xhr = {};
             this.server.addRequest(xhr);
@@ -189,7 +189,7 @@ describe("fakeServerWithClock", function () {
         });
 
         it("calls original respond", function () {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             var obj = {};
             var respond = sandbox.stub(sinonFakeServer, "respond").returns(obj);
 
@@ -201,7 +201,7 @@ describe("fakeServerWithClock", function () {
         });
 
         it("does not trigger a timeout event", function () {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
 
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/");

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -97,7 +97,7 @@ describe("sinonFakeServer", function () {
     });
 
     it("fakes XMLHttpRequest", function () {
-        var sandbox = sinon.sandbox.create();
+        var sandbox = sinon.createSandbox();
         sandbox.stub(fakeXhr, "useFakeXMLHttpRequest").returns({
             restore: sinon.stub()
         });
@@ -109,7 +109,7 @@ describe("sinonFakeServer", function () {
     });
 
     it("mirrors FakeXMLHttpRequest restore method", function () {
-        var sandbox = sinon.sandbox.create();
+        var sandbox = sinon.createSandbox();
         this.server = sinonFakeServer.create();
         var restore = sandbox.stub(FakeXMLHttpRequest, "restore");
         this.server.restore();
@@ -191,7 +191,7 @@ describe("sinonFakeServer", function () {
 
     describe(".respondWith", function () {
         beforeEach(function () {
-            this.sandbox = sinon.sandbox.create();
+            this.sandbox = sinon.createSandbox();
 
             this.server = sinonFakeServer.create({
                 setTimeout: this.sandbox.spy(),

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -4,7 +4,6 @@ var referee = require("@sinonjs/referee");
 var proxyquire = require("proxyquire");
 var sinonStub = require("sinon").stub;
 var sinonSpy = require("sinon").spy;
-var sinonSandbox = require("sinon").sandbox;
 
 var sinon = require("sinon");
 var extend = require("just-extend");
@@ -1055,7 +1054,7 @@ describe("FakeXMLHttpRequest", function () {
 
     describe(".respond", function () {
         beforeEach(function () {
-            this.sandbox = sinonSandbox.create();
+            this.sandbox = sinon.createSandbox();
             this.xhr = new FakeXMLHttpRequest({
                 setTimeout: this.sandbox.spy(),
                 useImmediateExceptions: false
@@ -1402,7 +1401,7 @@ describe("FakeXMLHttpRequest", function () {
 
     describe(".triggerTimeout", function () {
         beforeEach(function () {
-            this.sandbox = sinonSandbox.create();
+            this.sandbox = sinon.createSandbox();
             this.xhr = new FakeXMLHttpRequest();
         });
 
@@ -2396,7 +2395,7 @@ describe("FakeXMLHttpRequest", function () {
 
         describe("timeout", function () {
             beforeEach(function () {
-                this.sandbox = sinonSandbox.create({ useFakeTimers: true });
+                this.sandbox = sinon.createSandbox({ useFakeTimers: true });
             });
 
             afterEach(function () {


### PR DESCRIPTION
Trivial fix to:
```
`sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`
```