### PR TITLE
Dedupe readstatechange event

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -571,7 +571,6 @@ function fakeXMLHttpRequestFor(globalScope) {
             this.errorFlag = false;
             this.sendFlag = this.async;
             clearResponse(this);
-            this.readyStateChange(FakeXMLHttpRequest.OPENED);
 
             if (typeof this.onSend === "function") {
                 this.onSend(this);

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -686,23 +686,6 @@ describe("FakeXMLHttpRequest", function () {
             assert.isFalse(this.xhr.sendFlag);
         });
 
-        it("dispatches onreadystatechange", function () {
-            var event, state;
-            this.xhr.open("POST", "/", false);
-
-            this.xhr.onreadystatechange = function (e) {
-                event = e;
-                state = this.readyState;
-            };
-
-            this.xhr.send("Data");
-
-            assert.equals(state, FakeXMLHttpRequest.OPENED);
-            assert.equals(event.type, "readystatechange");
-            assert.defined(event.target);
-            assert.defined(event.currentTarget);
-        });
-
         it("should not duplicate readystatechange events", function (done) {
             var events = [];
             var xhr = this.xhr;
@@ -719,19 +702,6 @@ describe("FakeXMLHttpRequest", function () {
 
             xhr.send("Data");
             xhr.respond(200, {}, "");
-        });
-
-        it("dispatches event using DOM Event interface", function () {
-            var listener = sinonSpy();
-            this.xhr.open("POST", "/", false);
-            this.xhr.addEventListener("readystatechange", listener);
-
-            this.xhr.send("Data");
-
-            assert(listener.calledOnce);
-            assert.equals(listener.args[0][0].type, "readystatechange");
-            assert.defined(listener.args[0][0].target);
-            assert.defined(listener.args[0][0].currentTarget);
         });
 
         it("dispatches onSend callback if set", function () {

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -703,6 +703,24 @@ describe("FakeXMLHttpRequest", function () {
             assert.defined(event.currentTarget);
         });
 
+        it("should not duplicate readystatechange events", function (done) {
+            var events = [];
+            var xhr = this.xhr;
+
+            xhr.addEventListener("readystatechange", function () {
+                events.push(xhr.readyState);
+
+                if (xhr.readyState === 4) {
+                    assert.equals(events, [1, 2, 3, 4]);
+                    done();
+                }
+            });
+            xhr.open("POST", "/", true);
+
+            xhr.send("Data");
+            xhr.respond(200, {}, "");
+        });
+
         it("dispatches event using DOM Event interface", function () {
             var listener = sinonSpy();
             this.xhr.open("POST", "/", false);


### PR DESCRIPTION
I removed two tests that asserted that a readystatechange event should fire after `xhr.send()`. I used [jsbin](https://jsbin.com/fepecig/edit?js,console) to confirm that these are indeed bad tests. 

This fixes #89.