### PR TITLE
Ugrade lolex to v5 and don't detect globals

### DIFF
--- a/lib/fake-server/fake-server-with-clock.test.js
+++ b/lib/fake-server/fake-server-with-clock.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var JSDOM = require("jsdom").JSDOM;
-var DOMParser = new JSDOM().window.DOMParser;
 var referee = require("@sinonjs/referee");
 var setupDOM = require("jsdom-global");
 var sinon = require("sinon");
@@ -11,6 +10,12 @@ var sinonFakeServer = require("./index");
 
 var lolex = require("lolex");
 var FakeXMLHttpRequest = require("../fake-xhr").FakeXMLHttpRequest;
+
+var JSDOMParser;
+if (JSDOM) {
+    JSDOMParser = new JSDOM().window.DOMParser;
+}
+
 var assert = referee.assert;
 var refute = referee.refute;
 
@@ -18,13 +23,17 @@ var globalSetTimeout = setTimeout;
 
 describe("fakeServerWithClock", function () {
     beforeEach(function () {
-        global.DOMParser = DOMParser;
-        this.cleanupDOM = setupDOM();
+        if (JSDOMParser) {
+            global.DOMParser = JSDOMParser;
+            this.cleanupDOM = setupDOM();
+        }
     });
 
     afterEach(function () {
-        delete global.DOMParser;
-        this.cleanupDOM();
+        if (JSDOMParser) {
+            delete global.DOMParser;
+            this.cleanupDOM();
+        }
     });
 
     describe("without pre-existing fake clock", function () {

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -6,8 +6,12 @@ var JSDOM = require("jsdom").JSDOM;
 var sinon = require("sinon");
 var sinonFakeServer = require("./index");
 var fakeXhr = require("../fake-xhr/");
-var DOMParser = new JSDOM().window.DOMParser;
 var FakeXMLHttpRequest = fakeXhr.FakeXMLHttpRequest;
+
+var JSDOMParser;
+if (JSDOM) {
+    JSDOMParser = new JSDOM().window.DOMParser;
+}
 
 var assert = referee.assert;
 var refute = referee.refute;
@@ -16,8 +20,10 @@ var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
 
 describe("sinonFakeServer", function () {
     beforeEach(function () {
-        global.DOMParser = DOMParser;
-        this.cleanupDOM = setupDOM();
+        if (JSDOMParser) {
+            global.DOMParser = JSDOMParser;
+            this.cleanupDOM = setupDOM();
+        }
     });
 
     afterEach(function () {
@@ -25,8 +31,10 @@ describe("sinonFakeServer", function () {
             this.server.restore();
         }
 
-        delete global.DOMParser;
-        this.cleanupDOM();
+        if (JSDOMParser) {
+            delete global.DOMParser;
+            this.cleanupDOM();
+        }
     });
 
     it("provides restore method", function () {

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var TextEncoder = require("@sinonjs/text-encoding").TextEncoder;
+var GlobalTextEncoder = typeof TextEncoder !== "undefined"
+    ? TextEncoder
+    : require("@sinonjs/text-encoding").TextEncoder;
 
 var configureLogError = require("../configure-logger");
 var sinonEvent = require("../event");
@@ -119,7 +121,7 @@ function convertToArrayBuffer(body, encoding) {
         return body;
     }
 
-    return new TextEncoder(encoding || "utf-8").encode(body).buffer;
+    return new GlobalTextEncoder(encoding || "utf-8").encode(body).buffer;
 }
 
 function isXmlContentType(contentType) {
@@ -777,4 +779,7 @@ function fakeXMLHttpRequestFor(globalScope) {
     };
 }
 
-module.exports = extend(fakeXMLHttpRequestFor(global), { fakeXMLHttpRequestFor: fakeXMLHttpRequestFor });
+var globalObject = typeof global !== "undefined" ? global : window;
+module.exports = extend(fakeXMLHttpRequestFor(globalObject), {
+    fakeXMLHttpRequestFor: fakeXMLHttpRequestFor
+});

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1,3 +1,4 @@
+/*global ActiveXObject*/
 "use strict";
 
 var referee = require("@sinonjs/referee");
@@ -9,12 +10,15 @@ var sinon = require("sinon");
 var extend = require("just-extend");
 var JSDOM = require("jsdom").JSDOM;
 
-var TextEncoder = global.TextEncoder || require("@sinonjs/text-encoding").TextEncoder;
-var DOMParser = new JSDOM().window.DOMParser;
+var GlobalTextEncoder = typeof TextEncoder !== "undefined"
+    ? TextEncoder
+    : require("@sinonjs/text-encoding").TextEncoder;
 var assert = referee.assert;
 var refute = referee.refute;
 
-var globalActiveXObject = global.ActiveXObject;
+var globalActiveXObject = typeof ActiveXObject !== "undefined"
+    ? ActiveXObject
+    : undefined;
 
 var supportsFormData = typeof FormData !== "undefined";
 var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
@@ -25,7 +29,12 @@ var setupDOM = require("jsdom-global");
 var globalXMLHttpRequest,
     sinonFakeXhr,
     FakeXMLHttpRequest,
-    fakeXhr;
+    fakeXhr,
+    JSDOMParser;
+
+if (JSDOM) {
+    JSDOMParser = new JSDOM().window.DOMParser;
+}
 
 function fakeXhrSetUp() {
     fakeXhr = sinonFakeXhr.useFakeXMLHttpRequest();
@@ -243,16 +252,20 @@ function loadModule() {
 
 describe("FakeXMLHttpRequest", function () {
     beforeEach(function () {
-        global.DOMParser = DOMParser;
-        this.cleanupDOM = setupDOM();
+        if (JSDOMParser) {
+            global.DOMParser = JSDOMParser;
+            this.cleanupDOM = setupDOM();
+        }
         globalXMLHttpRequest = global.XMLHttpRequest;
         loadModule();
     });
 
     afterEach(function () {
-        delete global.DOMParser;
         delete FakeXMLHttpRequest.onCreate;
-        this.cleanupDOM();
+        if (JSDOMParser) {
+            delete global.DOMParser;
+            this.cleanupDOM();
+        }
     });
 
     it("is constructor", function () {
@@ -1582,7 +1595,7 @@ describe("FakeXMLHttpRequest", function () {
 
                     this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "a test buffer");
 
-                    var expected = new TextEncoder("utf-8").encode("a test buffer").buffer;
+                    var expected = new GlobalTextEncoder("utf-8").encode("a test buffer").buffer;
                     assertArrayBufferMatches(this.xhr.response, expected);
                 });
 
@@ -1593,7 +1606,7 @@ describe("FakeXMLHttpRequest", function () {
 
                     this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "\xFF");
 
-                    var expectedBuffer = new TextEncoder("utf-8").encode("\xFF").buffer;
+                    var expectedBuffer = new GlobalTextEncoder("utf-8").encode("\xFF").buffer;
 
                     assertArrayBufferMatches(this.xhr.response, expectedBuffer);
                 });
@@ -2561,11 +2574,13 @@ describe("FakeXMLHttpRequest", function () {
         var win;
 
         beforeEach(function () {
-            win = new JSDOM().window;
-            win.DOMParser = DOMParser;
-
+            if (JSDOM) {
+                win = new JSDOM().window;
+                win.DOMParser = JSDOMParser;
+            } else {
+                win = window;
+            }
             var scopedSinonFakeXhr = sinonFakeXhr.fakeXMLHttpRequestFor(win);
-
             globalXMLHttpRequest = win.XMLHttpRequest;
             fakeXhr = scopedSinonFakeXhr.useFakeXMLHttpRequest();
             FakeXMLHttpRequest = scopedSinonFakeXhr.FakeXMLHttpRequest;

--- a/package-lock.json
+++ b/package-lock.json
@@ -684,9 +684,9 @@
       "dev": true
     },
     "brout": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/brout/-/brout-1.2.0.tgz",
-      "integrity": "sha1-B3Hav3ltMS8KfB8SgeAPdmDPcC8=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/brout/-/brout-1.3.0.tgz",
+      "integrity": "sha512-wCMjZMH6sCUytoS/aqJBajJREN2wS1GnsNyBqB/Ss1hrcCh0no+Zgk+ebFp9s2yh5lxGfXBRXwNH2N3Ma2RFdQ==",
       "dev": true,
       "requires": {
         "through2": "^2.0.0"
@@ -1754,14 +1754,14 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -2191,18 +2191,6 @@
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4200,9 +4188,9 @@
       }
     },
     "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.0.1.tgz",
+      "integrity": "sha512-CDEwkXui3ZrulrA+f4ewVuEo5rOXLrVhfLLG7FS+gaP5qhdGMaKLWCtK0crVZRhHiNRQwPAdP7KtRyEQRFQa7g=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -4427,12 +4415,12 @@
       }
     },
     "mocaccino": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.1.tgz",
-      "integrity": "sha512-/sYoNH7bl+73XZEtcFt0xLt9WZckr65FDzlW2MumQbE21JFJaXrtlSs+j9rfucZmw/yzFiBYL+apQmlw/0GP6A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.2.tgz",
+      "integrity": "sha512-lTlZ47MiMVco1gQhYGh75/U6t6cMNxLVhQTLNsJWPZlWY9dlF+SS9vKrnjaNpRzYThh8yVJpI8+hpChyUj+Qzg==",
       "dev": true,
       "requires": {
-        "brout": "^1.1.0",
+        "brout": "^1.3.0",
         "listen": "^1.0.0",
         "mocha": "^5.2.0",
         "resolve": "^1.8.1",
@@ -4629,19 +4617,19 @@
       }
     },
     "mochify": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/mochify/-/mochify-6.4.1.tgz",
-      "integrity": "sha512-jwmt92uxZNCevhzXkCllwWiqfLINM29w/L8bJr7mRLwDQTeCF4Zm1WgQaG/vXkznai/scTNqwXeMJzEno4d7jw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/mochify/-/mochify-6.6.0.tgz",
+      "integrity": "sha512-4rM4N/+sevEEa3RKq3VAcMXMBEWgLtXOgdrvBUDuRr2Bne91C+Ka5yQv9cXHEbS7iQm/YAbgszyHkBHWMuX+4w==",
       "dev": true,
       "requires": {
-        "brout": "^1.1.0",
+        "brout": "^1.3.0",
         "browserify": "^16.2.3",
         "consolify": "^2.1.0",
         "coverify": "^1.4.1",
         "glob": "^7.1.2",
         "mime": "^2.3.1",
         "min-wd": "^2.11.0",
-        "mocaccino": "^4.1.0",
+        "mocaccino": "^4.1.2",
         "mocha": "^5.2.0",
         "puppeteer": "^1.19.0",
         "resolve": "^1.5.0",
@@ -4810,6 +4798,14 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+          "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+          "dev": true
+        }
       }
     },
     "node-environment-flags": {
@@ -4912,7 +4908,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -4935,7 +4931,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
@@ -4944,7 +4940,7 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         }
@@ -5943,7 +5939,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,18 @@
   "main": "lib/index.js",
   "module": "nise.js",
   "scripts": {
-    "bundle": "browserify -s nise -o nise.js lib/index.js",
+    "bundle": "browserify --no-detect-globals -s nise -o nise.js lib/index.js",
     "lint": "eslint .",
     "prepublish": "npm run bundle",
     "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "mocha lib/**/*.test.js",
     "test:coverage": "nyc --reporter=lcov --reporter=text --all npm test -- --reporter dot",
-    "test:headless": "mochify --https-server --plugin [ proxyquire-universal ] lib/**/*.test.js"
+    "test:headless": "mochify --https-server --plugin [ proxyquire-universal ] --no-detect-globals test/global-hack.js lib/**/*.test.js"
+  },
+  "browser": {
+    "jsdom": false,
+    "jsdom-global": false,
+    "@sinonjs/text-encoding": false
   },
   "author": "",
   "license": "BSD-3-Clause",
@@ -49,7 +54,7 @@
     "jsdom": "^15.1.1",
     "jsdom-global": "3.0.2",
     "mocha": "^6.2.0",
-    "mochify": "^6.3.0",
+    "mochify": "^6.6.0",
     "nyc": "^14.1.1",
     "proxyquire": "^1.8.0",
     "proxyquire-universal": "^2.1.0",
@@ -60,7 +65,7 @@
     "@sinonjs/formatio": "^3.2.1",
     "@sinonjs/text-encoding": "^0.7.1",
     "just-extend": "^4.0.2",
-    "lolex": "^4.1.0",
+    "lolex": "^5.0.1",
     "path-to-regexp": "^1.7.0"
   },
   "husky": {

--- a/test/global-hack.js
+++ b/test/global-hack.js
@@ -1,0 +1,5 @@
+"use strict";
+
+if (typeof global === "undefined") {
+    window.global = window;
+}


### PR DESCRIPTION
This integrates the latest lolex and introduces the `--no-detect-globals` flag for browserify bundles and tests.

There is also a solution for running the tests using JSDOM on node and the actual DOM in headless chrome.

Note that we used to browserify `jsdom`, `jsdom-global` and `@sinonjs/text-encoding`. Putting those on the ignore list speeds up test runs significantly.

The `global-hack.js` thing is needed due to the circular dependencies that we have. Once Sinon includes all the latest, this can be removed.