### PR TITLE
Rename package to @sinonjs/fake-xhr-and-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
 workflows:
   version: 2
-  nise:
+  verify:
     jobs:
       - install-dependencies
       - lint:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 coverage/
 site/
-nise.js
+fake-xhr-and-server.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
-nise.js
+fake-xhr-and-server.js
 coverage/
 site/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# nise (偽)
+# `@sinonjs/fake-xhr-and-server`
 
-[![npm version](https://img.shields.io/npm/v/nise.svg?style=flat)](https://www.npmjs.com/package/nise)
-[![CircleCI](https://circleci.com/gh/sinonjs/nise.svg?style=svg)](https://circleci.com/gh/sinonjs/nise)
-[![codecov](https://codecov.io/gh/sinonjs/nise/branch/master/graph/badge.svg)](https://codecov.io/gh/sinonjs/nise)
+[![npm version](https://img.shields.io/npm/v/@sinonjs/fake-xhr-and-server.svg?style=flat)](https://www.npmjs.com/package/@sinonjs/fake-xhr-and-server)
+[![CircleCI](https://circleci.com/gh/sinonjs/fake-xhr-and-server.svg?style=svg)](https://circleci.com/gh/sinonjs/fake-xhr-and-server)
+[![codecov](https://codecov.io/gh/sinonjs/fake-xhr-and-server/branch/master/graph/badge.svg)](https://codecov.io/gh/sinonjs/fake-xhr-and-server)
 
 fake XHR and Server
 
-Documentation: http://sinonjs.github.io/nise/
+Documentation: http://sinonjs.github.io/fake-xhr-and-server/
 
 ## Backers
 
@@ -81,4 +81,4 @@ Become a sponsor and get your logo on our README on GitHub with a link to your s
 
 ## Licence
 
-nise was released under [BSD-3](LICENSE)
+`@sinonjs/fake-xhr-and-server` was released under [BSD-3](LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-﻿# nise (偽)
+# `@sinonjs/fake-xhr-and-server`
 
 fake XHR and Server
 
-This module has been extracted from [Sinon.JS][sinon] and can be used standalone. Sinon.JS will always be the "full package". However, there are use cases, where fake XHR and fake Server are needed but the rest of Sinon.JS not. That's the scenario of nise.
+This module has been extracted from [Sinon.JS][sinon] and can be used standalone. Sinon.JS will always be the "full package". However, there are use cases, where fake XHR and fake Server are needed but the rest of Sinon.JS not. That's the scenario of `@sinonjs/fake-xhr-and-server`.
 
 ## Fake `XMLHttpRequest`
 
@@ -12,7 +12,7 @@ several interfaces for manipulating objects created by it.
 Also fakes native `XMLHttpRequest` and `ActiveXObject` (when available, and only for `XMLHTTP` progids). Helps with testing requests made with `XHR`.
 
 ```js
-var fakeXhr = require("nise").fakeXhr;
+var fakeXhr = require("@sinonjs/fake-xhr-and-server").fakeXhr;
 var sinon = require("sinon");
 
 {
@@ -200,7 +200,7 @@ High-level API to manipulate `FakeXMLHttpRequest` instances.
 <small>For help with handling JSON-P please refer to our [notes below](#json-p)</small>
 
 ```js
-var fakeServer = require("nise").fakeServer;
+var fakeServer = require("@sinonjs/fake-xhr-and-server").fakeServer;
 var sinon = require("sinon");
 
 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,3 @@
-site_name: nise
+site_name: "@sinonjs/fake-xhr-and-server"
 theme: readthedocs
-repo_url: https://github.com/sinonjs/nise/
+repo_url: https://github.com/sinonjs/fake-xhr-and-server/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nise",
+  "name": "@sinonjs/fake-xhr-and-server",
   "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -316,17 +316,6 @@
             "type-detect": "^4.0.8"
           }
         }
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
-      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.0.2",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
       }
     },
     "@sinonjs/text-encoding": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nise",
+  "name": "@sinonjs/fake-xhr-and-server",
   "version": "3.0.1",
   "description": "Fake XHR and server",
   "keywords": [
@@ -12,12 +12,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/sinonjs/nise.git"
+    "url": "http://github.com/sinonjs/fake-xhr-and-server.git"
   },
   "main": "lib/index.js",
-  "module": "nise.js",
+  "module": "fake-xhr-and-server.js",
   "scripts": {
-    "bundle": "browserify --no-detect-globals -s nise -o nise.js lib/index.js",
+    "bundle": "browserify --no-detect-globals -s FakeXhrAndServer -o fake-xhr-and-server.js lib/index.js",
     "lint": "eslint .",
     "prepublish": "npm run bundle",
     "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
@@ -33,13 +33,13 @@
   "license": "BSD-3-Clause",
   "nyc": {
     "exclude": [
-      "nise.js",
+      "fake-xhr-and-server.js",
       "coverage/**",
       "**/*.test.js"
     ]
   },
   "files": [
-    "nise.js",
+    "fake-xhr-and-server.js",
     "lib/**/*.js"
   ],
   "devDependencies": {


### PR DESCRIPTION
This PR renames the package to `@sinonjs/fake-xhr-and-server`.

#### Purpose

It was suggested that we rename this package to have a less confusing name (I can't recall who suggested it, or in which communication channel).

I will soon be doing a larger effort in improving the documentation of Sinon and associated libraries. I thought it would be beneficial to that effort to get the rename of packages out of the way first.

See https://github.com/sinonjs/sinon/issues/1651

#### Plan

1. Rename repository
1. Merge this branch
1. Bump the major version
1. Publish the renamed package to `npm` registry
1. Deprecate the `nise` package in the `npm` registry
1. Update `sinon` to use the new package

#### How to verify

1. Check out this branch
1. (this repo): `npm ci`
1. (this repo): `npm link`
1. Check out this companion branch: https://github.com/mroderick/sinon/tree/use-sinon-fake-xhr-and-server
1. (sinon branch): `npm ci`
1. (sinon branch): `npm link @sinonjs/fake-xhr-and-server`
1. Observe tests pass