### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4469,15 +4469,6 @@
         "chalk": "^2.0.1"
       }
     },
-    "lolex": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "make-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
@@ -5140,16 +5131,16 @@
       "dev": true
     },
     "nise": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
-      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.1.tgz",
+      "integrity": "sha512-10PKL272rqg80o2RsWcTT6X9cDYqJ4kXqPTf8yCXPc9hbphZSDmbiG5FqUNeR5nouKCQMM24ld45kgYnBdx2rw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
         "@sinonjs/formatio": "^4.0.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       },
       "dependencies": {
@@ -6552,28 +6543,30 @@
       "dev": true
     },
     "sinon": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
-      "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/formatio": "^4.0.1",
-        "@sinonjs/samsam": "^4.2.2",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
         "diff": "^4.0.2",
-        "lolex": "^5.1.2",
-        "nise": "^3.0.1",
+        "nise": "^4.0.1",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
-        "@sinonjs/formatio": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
-          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+        "@sinonjs/samsam": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.2.tgz",
+          "integrity": "sha512-p3yrEVB5F/1wI+835n+X8llOGRgV8+jw5BHQ/cJoLBUXXZ5U8Tr5ApwPc4L4av/vjla48kVPoN0t6dykQm+Rvg==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^1",
-            "@sinonjs/samsam": "^4.2.0"
+            "@sinonjs/commons": "^1.6.0",
+            "@sinonjs/formatio": "^5.0.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
           }
         },
         "diff": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,22 +286,23 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
-      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
       "requires": {
         "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^4.2.0"
+        "@sinonjs/samsam": "^5.0.2"
       },
       "dependencies": {
         "@sinonjs/samsam": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
-          "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.2.tgz",
+          "integrity": "sha512-p3yrEVB5F/1wI+835n+X8llOGRgV8+jw5BHQ/cJoLBUXXZ5U8Tr5ApwPc4L4av/vjla48kVPoN0t6dykQm+Rvg==",
           "requires": {
             "@sinonjs/commons": "^1.6.0",
-            "array-from": "^2.1.1",
-            "lodash.get": "^4.4.2"
+            "@sinonjs/formatio": "^5.0.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
           }
         }
       }
@@ -320,6 +321,18 @@
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
         "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^4.2.0"
+          }
+        }
       }
     },
     "@sinonjs/samsam": {
@@ -581,7 +594,8 @@
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-map": {
       "version": "0.0.0",
@@ -5137,6 +5151,18 @@
         "just-extend": "^4.0.2",
         "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^4.2.0"
+          }
+        }
       }
     },
     "node-environment-flags": {
@@ -6540,6 +6566,16 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^4.2.0"
+          }
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "proxyquire": "^2.1.3",
     "proxyquire-universal": "^2.1.0",
     "proxyquireify": "^3.2.1",
-    "sinon": "^8.0.2"
+    "sinon": "^9.0.0"
   },
   "dependencies": {
     "@sinonjs/commons": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@sinonjs/commons": "^1.7.0",
     "@sinonjs/fake-timers": "^6.0.0",
-    "@sinonjs/formatio": "^4.0.1",
+    "@sinonjs/formatio": "^5.0.1",
     "@sinonjs/text-encoding": "^0.7.1",
     "just-extend": "^4.0.2",
     "path-to-regexp": "^1.7.0"


### PR DESCRIPTION
This PR aims at reducing duplication of dependencies when installing Sinon, see https://github.com/sinonjs/sinon/issues/2224.

~~Since I am touching the code anyway, I am also replacing `sinon` and `@sinonjs/referee` with `@sinonjs/referee-sinon`.~~ Upgrading Sinon on it's own instead.

~~Once https://github.com/sinonjs/referee-sinon/pull/82 has been merged and released to `npm`, this branch can be updated to use the newly released version of `@sinonjs/referee-sinon`.~~ Done!