### PR TITLE
Add support for responseURL to fakeXHR

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -804,6 +804,8 @@ function fakeXMLHttpRequestFor(globalScope) {
             this.setStatus(status);
             this.setResponseHeaders(headers || {});
             this.setResponseBody(body || "");
+
+            this.responseURL = this.url;
         },
 
         uploadProgress: function uploadProgress(progressEventRaw) {

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1907,6 +1907,26 @@ describe("FakeXMLHttpRequest", function() {
         });
     });
 
+    describe(".responseURL", function() {
+        beforeEach(function() {
+            this.xhr = new FakeXMLHttpRequest();
+        });
+
+        it("should set responseURL after response", function() {
+            this.xhr.open("GET", "/");
+
+            assert.isUndefined(this.xhr.responseURL);
+
+            this.xhr.send();
+
+            assert.isUndefined(this.xhr.responseURL);
+
+            this.xhr.respond(200, {}, "");
+
+            assert.equals(this.xhr.responseURL, "/");
+        });
+    });
+
     describe("stub XHR", function() {
         beforeEach(fakeXhrSetUp);
         afterEach(fakeXhrTearDown);


### PR DESCRIPTION
Source: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL
Standard: https://xhr.spec.whatwg.org/#the-responseurl-attribute

This was a quick fix to an issue I was seeing in my tests. It should set the `resposneURL` on the XHR object after the response is set, so I think this is the best place for it. It also should follow all redirects, which I haven't implemented (yet). Got some questions:

1. Is this the right place to put it?
2. In nise, do I pluck `Location` from the response headers and set that as the `responseURL`, to "follow redirects"?

