### PR TITLE
Fix-origin-replacement-w-portnum

### DIFF
--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -236,6 +236,13 @@ var fakeServer = {
             method = null;
         }
 
+        // Escape port number to prevent "named" parameters in 'path-to-regexp' module
+        if (typeof url === "string" && url !== "" && /:[0-9]+\//.test(url)) {
+            var m = url.match(/^(https?:\/\/.*?):([0-9]+\/.*)$/);
+            // eslint-disable-next-line no-param-reassign
+            url = m[1] + "\\:" + m[2];
+        }
+
         push.call(this.responses, {
             method: method,
             url:

--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -36,7 +36,7 @@ function getDefaultWindowLocation() {
     var winloc = {
         hostname: "localhost",
         port: process.env.PORT || 80,
-        protocol: "http"
+        protocol: "http:"
     };
     winloc.host =
         winloc.hostname +

--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -33,7 +33,15 @@ function responseArray(handler) {
 }
 
 function getDefaultWindowLocation() {
-    return { host: "localhost", protocol: "http" };
+    var winloc = {
+        hostname: "localhost",
+        port: process.env.PORT || 80,
+        protocol: "http"
+    };
+    winloc.host =
+        winloc.hostname +
+        (String(winloc.port) === "80" ? "" : ":" + winloc.port);
+    return winloc;
 }
 
 function getWindowLocation() {
@@ -73,12 +81,12 @@ function matchOne(response, reqMethod, reqUrl) {
 function match(response, request) {
     var wloc = getWindowLocation();
 
-    var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
+    var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host + "/");
 
     var requestUrl = request.url;
 
     if (!/^https?:\/\//.test(requestUrl) || rCurrLoc.test(requestUrl)) {
-        requestUrl = requestUrl.replace(rCurrLoc, "");
+        requestUrl = requestUrl.replace(rCurrLoc, "/");
     }
 
     if (matchOne(response, this.getHTTPMethod(request), requestUrl)) {

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -540,14 +540,11 @@ describe("sinonFakeServer", function() {
         });
 
         it("recognizes request with hostname", function() {
+            // set the host value, as jsdom default is 'about:blank'
+            setupDOM("", { url: "http://localhost/" });
             this.server.respondWith("/", [200, {}, "Yep"]);
             var xhr = new FakeXMLHttpRequest();
             var loc = window.location;
-
-            if (!loc.host) {
-                // set the host value, as jsdom doesn't supply one
-                loc.host = "localhost";
-            }
 
             xhr.open("GET", loc.protocol + "//" + loc.host + "/", true);
             xhr.send();

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -558,6 +558,22 @@ describe("sinonFakeServer", function() {
             assert.equals(xhr.respond.args[0], [200, {}, "Yep"]);
         });
 
+        it("responds to matching paths with port number in external URL", function() {
+            // setup server & client
+            setupDOM("", { url: "http://localhost/" });
+            var localAPI = "http://localhost:5000/ping";
+            this.server.respondWith("GET", localAPI, "Pong");
+
+            // Create fake client request
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", localAPI, true);
+            xhr.send();
+            sinon.spy(xhr, "respond");
+
+            this.server.respond();
+
+            assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
+        });
         it("accepts URLS which are common route DSLs", function() {
             this.server.respondWith("/foo/*", [200, {}, "Yep"]);
 

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -594,6 +594,54 @@ describe("sinonFakeServer", function() {
             assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
         });
 
+        it("responds although window.location is undefined", function() {
+            // setup server & client
+            this.cleanupDOM(); // remove window, Document, etc.
+            var origin = "http://localhost";
+            this.server.respondWith("GET", "/ping", "Pong");
+
+            // Create fake client request
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", origin + "/ping", true);
+            xhr.send();
+            sinon.spy(xhr, "respond");
+
+            this.server.respond();
+
+            assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
+        });
+
+        // React Native on Android places location on window.window
+        it("responds as expected for React Native on Android with window.window.location", function() {
+            this.cleanupDOM(); // remove default window, Document, etc.
+            // setup client
+            // Build Android like format (manual jsdom, with window.window inset)
+            var html =
+                // eslint-disable-next-line quotes
+                '<!doctype html><html><head><meta charset="utf-8">' +
+                "</head><body></body></html>";
+            var options = {};
+            var document = new JSDOM(html, options);
+            var window = document.window;
+            global.document = window.document;
+            global.window = { window: window };
+            window.console = global.console;
+
+            // setup server
+            var url = "http://localhost";
+            this.server.respondWith("GET", url, "Pong");
+
+            // Create fake client request
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", url, true);
+            xhr.send();
+            sinon.spy(xhr, "respond");
+
+            this.server.respond();
+
+            assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
+        });
+
         it("accepts URLS which are common route DSLs", function() {
             this.server.respondWith("/foo/*", [200, {}, "Yep"]);
 

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -574,6 +574,29 @@ describe("sinonFakeServer", function() {
 
             assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
         });
+
+        it("responds to matching paths when port numbers are different", function() {
+            // setup server & client
+            setupDOM("", { url: "http://localhost:8080/" });
+            var localAPI = "http://localhost:5000/ping";
+            this.server.respondWith("GET", localAPI, "Pong");
+            this.server.respondWith(
+                "GET",
+                "http://localhost:8080/ping",
+                "Ding"
+            );
+
+            // Create fake client request
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", localAPI, true);
+            xhr.send();
+            sinon.spy(xhr, "respond");
+
+            this.server.respond();
+
+            assert.equals(xhr.respond.args[0], [200, {}, "Pong"]);
+        });
+
         it("accepts URLS which are common route DSLs", function() {
             this.server.respondWith("/foo/*", [200, {}, "Yep"]);
 


### PR DESCRIPTION
**Purpose:**
Fixes request matching errors when test cases call URLs that include port numbers as part of the URL origin.  This addresses the initial URL registration and the match errors to requests.  In depth descriptions are included in each of the commits of why the changes were made and unit tests were added to exemplify the functional correctness of the changes.

**Resolves:** #161, #162

**How to verify**
1. Check out this branch
2. Run `npm install`
3. Revert fake-server library before bug fixes. `git checkout master -- lib/fake-server/index.js`
4. Run `npm run test`. This branch includes 4 new unit tests to accompany the errors so during this test run. 3 of the tests will fail.
5. Review & validate the test cases written to understand what scenarios are fixed.  See it quickly with the command `$  sed -n 558,643p ./lib/fake-server/index.test.js | less -N`
6. Reset the primary library to this branch. `git checkout HEAD -- lib/fake-server/index.js`
7. Run `npm run test` again.  All tests will pass verifying there was no regression and the buggy scenarios were fixed. 
