### PR TITLE
feat: Allow responding with Blob or ArrayBuffer when responseType is `blob`

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -115,6 +115,20 @@ function verifyResponseBodyType(body, responseType) {
             );
             error.name = "InvalidBodyException";
         }
+    } else if (responseType === "blob") {
+        if (
+            !isString &&
+            !(body instanceof ArrayBuffer) &&
+            supportsBlob &&
+            !(body instanceof Blob)
+        ) {
+            error = new Error(
+                "Attempted to respond to fake XMLHttpRequest with " +
+                    body +
+                    ", which is not a string, ArrayBuffer, or Blob."
+            );
+            error.name = "InvalidBodyException";
+        }
     } else if (!isString) {
         error = new Error(
             "Attempted to respond to fake XMLHttpRequest with " +
@@ -357,6 +371,10 @@ function fakeXMLHttpRequestFor(globalScope) {
                 return null;
             }
         } else if (supportsBlob && responseType === "blob") {
+            if (body instanceof Blob) {
+                return body;
+            }
+
             var blobOptions = {};
             if (contentType) {
                 blobOptions.type = contentType;

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1744,6 +1744,45 @@ describe("FakeXMLHttpRequest", function() {
                     assertBlobMatches(this.xhr.response, "\xFF", done);
                 });
 
+                it("returns blob with correct binary data when using an arraybuffer", function(done) {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    var buffer = new Uint8Array([160, 64, 0, 0, 32, 193])
+                        .buffer;
+
+                    this.xhr.respond(
+                        200,
+                        { "Content-Type": "application/octet-stream" },
+                        buffer
+                    );
+
+                    assertBlobMatches(
+                        this.xhr.response,
+                        new Blob([buffer]),
+                        done
+                    );
+                });
+
+                it("returns blob with correct binary data when using a blob", function(done) {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    var blob = new Blob([
+                        new Uint8Array([160, 64, 0, 0, 32, 193]).buffer
+                    ]);
+
+                    this.xhr.respond(
+                        200,
+                        { "Content-Type": "application/octet-stream" },
+                        blob
+                    );
+
+                    assertBlobMatches(this.xhr.response, blob, done);
+                });
+
                 it("does parse utf-8 content outside ASCII range properly", function(done) {
                     this.xhr.responseType = "blob";
                     this.xhr.open("GET", "/");

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -995,6 +995,30 @@ describe("FakeXMLHttpRequest", function() {
             }, "InvalidBodyException");
         });
 
+        it("throws if body is not a string or arraybuffer and responseType='arraybuffer'", function() {
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/");
+            xhr.responseType = "arraybuffer";
+            xhr.send();
+            xhr.setResponseHeaders({});
+
+            assert.exception(function() {
+                xhr.setResponseBody({});
+            }, "InvalidBodyException");
+        });
+
+        it("throws if body is not a string, arraybuffer, or blob and responseType='blob'", function() {
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/");
+            xhr.responseType = "blob";
+            xhr.send();
+            xhr.setResponseHeaders({});
+
+            assert.exception(function() {
+                xhr.setResponseBody({});
+            }, "InvalidBodyException");
+        });
+
         if (supportsArrayBuffer) {
             describe("with ArrayBuffer support", function() {
                 it("invokes onreadystatechange for each chunk when responseType='arraybuffer'", function() {


### PR DESCRIPTION
Currently, when the responseType is `blob` the body must be a string which is then converted to a `utf8` ArrayBuffer which doesn't work for binary data. This allows you to respond with either an ArrayBuffer (which will get converted into a Blob) or Blob.