### PR TITLE
Feature: sinonFakeServer#respondWith(method, urlMatcher, body) overload 

### DIFF
--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -73,7 +73,8 @@ function matchOne(response, reqMethod, reqUrl) {
     var matchUrl =
         !url ||
         url === reqUrl ||
-        (typeof url.test === "function" && url.test(reqUrl));
+        (typeof url.test === "function" && url.test(reqUrl)) ||
+        (typeof url === "function" && url(reqUrl) === true);
 
     return matchMethod && matchUrl;
 }

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -369,6 +369,18 @@ describe("sinonFakeServer", function() {
             ]);
         });
 
+        it("responds to URL matched by url matcher function", function() {
+            this.server.respondWith(() => true, "FuncMatcher");
+
+            this.server.respond();
+
+            assert.equals(this.getPathAsync.respond.args[0], [
+                200,
+                {},
+                "FuncMatcher"
+            ]);
+        });
+
         it("does not respond to URL not matched by regexp", function() {
             this.server.respondWith(/^\/p.*/, "No regexp match");
 
@@ -377,8 +389,33 @@ describe("sinonFakeServer", function() {
             assert.equals(this.getRootAsync.respond.args[0], [404, {}, ""]);
         });
 
+        it("does not respond to URL not matched by function url matcher", function() {
+            this.server.respondWith(() => false, "No function match");
+
+            this.server.respond();
+
+            assert.equals(this.getRootAsync.respond.args[0], [404, {}, ""]);
+        });
+
         it("responds to all URLs matched by regexp", function() {
             this.server.respondWith(/^\/.*/, "Match all URLs");
+
+            this.server.respond();
+
+            assert.equals(this.getRootAsync.respond.args[0], [
+                200,
+                {},
+                "Match all URLs"
+            ]);
+            assert.equals(this.getPathAsync.respond.args[0], [
+                200,
+                {},
+                "Match all URLs"
+            ]);
+        });
+
+        it("responds to all URLs matched by function matcher", function() {
+            this.server.respondWith(() => true, "Match all URLs");
 
             this.server.respond();
 
@@ -408,6 +445,23 @@ describe("sinonFakeServer", function() {
                 200,
                 {},
                 "Falsy URL"
+            ]);
+        });
+
+        it("responds to no requests when function matcher is falsy", function() {
+            this.server.respondWith(() => false, "Falsy URL");
+
+            this.server.respond();
+
+            assert.equals(this.getRootAsync.respond.args[0], [
+                404,
+                {},
+                ""
+            ]);
+            assert.equals(this.getPathAsync.respond.args[0], [
+                404,
+                {},
+                ""
             ]);
         });
 
@@ -856,9 +910,63 @@ describe("sinonFakeServer", function() {
             assert(handler.calledOnce);
         });
 
+        function equalMatcher(expected) {
+            return function(test) {
+                return expected === test;
+            };
+        }
+
+        it("yields response to request function handler when url is a function that returns true", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", equalMatcher("/hello?world"), handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello?world");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(handler.calledOnce);
+        });
+
+        it("yields response to request function handler when url is a function that returns true with no Http Method specified", function() {
+            var handler = sinon.spy();
+            this.server.respondWith(equalMatcher("/hello?world"), handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello?world");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(handler.calledOnce);
+        });
+
         it("does not yield response to request function handler when method does not match", function() {
             var handler = sinon.spy();
             this.server.respondWith("GET", "/hello", handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("POST", "/hello");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(!handler.called);
+        });
+
+        it("does not yield response to request function handler when method does not match (using url mather function)", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", equalMatcher("/hello"), handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("POST", "/hello");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(!handler.called);
+        });
+
+        it("does not yield response to request function handler when method does not match (using url mather function)", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", equalMatcher("/hello"), handler);
             var xhr = new FakeXMLHttpRequest();
             xhr.open("POST", "/hello");
             xhr.send();
@@ -883,6 +991,42 @@ describe("sinonFakeServer", function() {
         it("does not yield response to request function handler when regexp url does not match", function() {
             var handler = sinon.spy();
             this.server.respondWith("GET", /\/a.*/, handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(!handler.called);
+        });
+
+        it("does not yield response to request function handler when urlMatcher function returns false", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", equalMatcher("/goodbye"), handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(!handler.called);
+        });
+
+        it("does not yield response to request function handler when urlMatcher function returns non Boolean truthy value", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", () => "truthy", handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(!handler.called);
+        });
+
+        it("does not yield response to request function handler when urlMatcher function returns non Boolean falsey value", function() {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", () => undefined, handler);
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello");
             xhr.send();

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -370,7 +370,9 @@ describe("sinonFakeServer", function() {
         });
 
         it("responds to URL matched by url matcher function", function() {
-            this.server.respondWith(() => true, "FuncMatcher");
+            this.server.respondWith(function() {
+                return true;
+            }, "FuncMatcher");
 
             this.server.respond();
 
@@ -390,7 +392,9 @@ describe("sinonFakeServer", function() {
         });
 
         it("does not respond to URL not matched by function url matcher", function() {
-            this.server.respondWith(() => false, "No function match");
+            this.server.respondWith(function() {
+                return false;
+            }, "No function match");
 
             this.server.respond();
 
@@ -415,7 +419,9 @@ describe("sinonFakeServer", function() {
         });
 
         it("responds to all URLs matched by function matcher", function() {
-            this.server.respondWith(() => true, "Match all URLs");
+            this.server.respondWith(function() {
+                return true;
+            }, "Match all URLs");
 
             this.server.respond();
 
@@ -449,20 +455,14 @@ describe("sinonFakeServer", function() {
         });
 
         it("responds to no requests when function matcher is falsy", function() {
-            this.server.respondWith(() => false, "Falsy URL");
+            this.server.respondWith(function() {
+                return false;
+            }, "Falsy URL");
 
             this.server.respond();
 
-            assert.equals(this.getRootAsync.respond.args[0], [
-                404,
-                {},
-                ""
-            ]);
-            assert.equals(this.getPathAsync.respond.args[0], [
-                404,
-                {},
-                ""
-            ]);
+            assert.equals(this.getRootAsync.respond.args[0], [404, {}, ""]);
+            assert.equals(this.getPathAsync.respond.args[0], [404, {}, ""]);
         });
 
         it("responds to all GET requests", function() {
@@ -918,7 +918,11 @@ describe("sinonFakeServer", function() {
 
         it("yields response to request function handler when url is a function that returns true", function() {
             var handler = sinon.spy();
-            this.server.respondWith("GET", equalMatcher("/hello?world"), handler);
+            this.server.respondWith(
+                "GET",
+                equalMatcher("/hello?world"),
+                handler
+            );
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello?world");
             xhr.send();
@@ -928,6 +932,7 @@ describe("sinonFakeServer", function() {
             assert(handler.calledOnce);
         });
 
+        // eslint-disable-next-line max-len
         it("yields response to request function handler when url is a function that returns true with no Http Method specified", function() {
             var handler = sinon.spy();
             this.server.respondWith(equalMatcher("/hello?world"), handler);
@@ -952,18 +957,7 @@ describe("sinonFakeServer", function() {
             assert(!handler.called);
         });
 
-        it("does not yield response to request function handler when method does not match (using url mather function)", function() {
-            var handler = sinon.spy();
-            this.server.respondWith("GET", equalMatcher("/hello"), handler);
-            var xhr = new FakeXMLHttpRequest();
-            xhr.open("POST", "/hello");
-            xhr.send();
-
-            this.server.respond();
-
-            assert(!handler.called);
-        });
-
+        // eslint-disable-next-line max-len
         it("does not yield response to request function handler when method does not match (using url mather function)", function() {
             var handler = sinon.spy();
             this.server.respondWith("GET", equalMatcher("/hello"), handler);
@@ -1012,9 +1006,16 @@ describe("sinonFakeServer", function() {
             assert(!handler.called);
         });
 
+        // eslint-disable-next-line max-len
         it("does not yield response to request function handler when urlMatcher function returns non Boolean truthy value", function() {
             var handler = sinon.spy();
-            this.server.respondWith("GET", () => "truthy", handler);
+            this.server.respondWith(
+                "GET",
+                function() {
+                    return "truthy";
+                },
+                handler
+            );
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello");
             xhr.send();
@@ -1024,9 +1025,16 @@ describe("sinonFakeServer", function() {
             assert(!handler.called);
         });
 
+        // eslint-disable-next-line max-len
         it("does not yield response to request function handler when urlMatcher function returns non Boolean falsey value", function() {
             var handler = sinon.spy();
-            this.server.respondWith("GET", () => undefined, handler);
+            this.server.respondWith(
+                "GET",
+                function() {
+                    return undefined;
+                },
+                handler
+            );
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello");
             xhr.send();


### PR DESCRIPTION
Feature: sinonFakeServer#respondWith(method, urlMatcher, body) where urlMatcher is a predicate. eg

```
function equalMatcher(requestUrl) {
    return "/hello" === requestUrl;
}
```

It's sort of an inplace replacement for the Regexp.
Also, it's my own feature request: sinonjs/sinon#2318