### PR TITLE
Simplify hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint -- --fix && npm run test",
-      "pre-push": "npm run lint && npm run test"
+      "pre-commit": "npm run lint"
     }
   }
 }


### PR DESCRIPTION
We don't need to run tests and lint all the time. CI gives fast feedback and prevents merging bad branches