### PR TITLE
Upgrade @sinonjs/fake-timers to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -366,9 +366,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.4.tgz",
+      "integrity": "sha512-fW3SzjLF0sjI0x1Opc7cUG4J/Nr4U0TXPNnKNAgrxA4xXsQNk6nypZK0yJg5FNw5cCo2yC/ZMdaVhDTKeeF6zg==",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -6107,6 +6107,17 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "node-environment-flags": {
@@ -7525,6 +7536,15 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.7.0",
-    "@sinonjs/fake-timers": "^6.0.0",
+    "@sinonjs/fake-timers": "^7.0.4",
     "@sinonjs/text-encoding": "^0.7.1",
     "just-extend": "^4.0.2",
     "path-to-regexp": "^1.7.0"


### PR DESCRIPTION
This PR upgrades `@sinonjs/fake-timers` to latest.

Ref: https://github.com/sinonjs/sinon/issues/2353