### PR TITLE
fix-missing-request-url in response

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -798,7 +798,7 @@ function fakeXMLHttpRequestFor(globalScope) {
 
         respond: function respond(status, headers, body) {
             this.responseURL = this.url;
-            
+
             this.setStatus(status);
             this.setResponseHeaders(headers || {});
             this.setResponseBody(body || "");

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -797,11 +797,11 @@ function fakeXMLHttpRequestFor(globalScope) {
         },
 
         respond: function respond(status, headers, body) {
+            this.responseURL = this.url;
+            
             this.setStatus(status);
             this.setResponseHeaders(headers || {});
             this.setResponseBody(body || "");
-
-            this.responseURL = this.url;
         },
 
         uploadProgress: function uploadProgress(progressEventRaw) {

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1163,13 +1163,13 @@ describe("FakeXMLHttpRequest", function() {
         it("sets response url", function() {
             var xhr = new FakeXMLHttpRequest();
             var uri = "/";
-            
+
             xhr.open("GET", uri);
             xhr.send();
             xhr.respond(200, {}, "");
 
-            assert.equals(xhr.responseURL, uri)
-        })
+            assert.equals(xhr.responseURL, uri);
+        });
 
         it("url is provided before onload event of the XHR object", function(done) {
             var xhr = new FakeXMLHttpRequest();

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1160,6 +1160,32 @@ describe("FakeXMLHttpRequest", function() {
             );
         });
 
+        it("sets response url", function() {
+            var xhr = new FakeXMLHttpRequest();
+            var uri = "/";
+            
+            xhr.open("GET", uri);
+            xhr.send();
+            xhr.respond(200, {}, "");
+
+            assert.equals(xhr.responseURL, uri)
+        })
+
+        it("url is provided before onload event of the XHR object", function(done) {
+            var xhr = new FakeXMLHttpRequest();
+            var uri = "/";
+            xhr.open("GET", uri);
+
+            xhr.onload = function() {
+                assert.same(this.responseURL, uri);
+
+                done();
+            };
+
+            xhr.send();
+            xhr.respond(200, {}, "");
+        });
+
         it("sets response text", function() {
             this.xhr.respond(200, {}, "'tis some body text");
 


### PR DESCRIPTION
### Purpose:
Fix the missing url parameter value that should of been passed from the initial xhr request to the xhr response object.  Currently the `responseURL` attribute is undefined when the event handler `onload()` is called.  This has a secondary effect on other network libraries like the `fetch()` API where the response object generated has a `res.url == ''`.  

In my investigation, I found that in the `nise` module in fake-xhr, during the `respond()` function, `setResponseBody()` initiates the`readyStateChange()` which subsequently calls the onload function of the xhr.  This causes the body data to be provided and processed by the xhr request handler all before returning to the `respond()` function to set the url. At this point, it was too late.

On the other side, when using `fetch()` (from `whatwg-fetch` module) to send the xhr request that`nise` then intercepts, the `fetch()` command returns the data to the response handler/resolves the promise during the `onload` event. When the onload event occurs, the response object is created and in order to set the url `fetch()` looks for 2 attributes in the xhr request: `xhr.responseURL` or `xhr.headers['X-Request-URL']`.  

This fix moves the variable assignment to before the onload event, therefore resolving the missing url value in the fetch() response object.

I added 2 unit tests to exemplify the flaw. The first adds additional coverage of the responseURL variable similarly to headers and status. And the second, shows the flaw during the onload response side of the xhr request.

### How to verify

1. Check out this branch
2. Run `npm install`
3. Revert fake-xhr library before bug fixes. `git checkout master -- lib/fake-xhr/index.js`
4. Run `npm test`. This branch includes 2 new unit tests to accompany the errors so during this test run 1 of the tests will fail.
5. Review & validate the test cases written to understand what scenarios are fixed. See it quickly with the command `$ sed -n 1163,1187p ./lib/fake-xhr/index.test.js | less -N`
6. Reset the primary library to this branch. `git checkout HEAD -- lib/fake-xhr/index.js`
7. Run `npm test` again. All tests will pass verifying there was no regression and the buggy scenarios were fixed.