### PR TITLE
fix respond() & readystatechange process flow

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -513,8 +513,6 @@ function fakeXMLHttpRequestFor(globalScope) {
                 false,
                 this
             );
-            var event, progress;
-
             if (typeof this.onreadystatechange === "function") {
                 try {
                     this.onreadystatechange(readyStateChangeEvent);
@@ -523,7 +521,11 @@ function fakeXMLHttpRequestFor(globalScope) {
                 }
             }
 
-            if (this.readyState === FakeXMLHttpRequest.DONE) {
+            if (this.readyState !== FakeXMLHttpRequest.DONE) {
+                this.dispatchEvent(readyStateChangeEvent);
+            } else {
+                var event, progress;
+
                 if (this.timedOut || this.aborted || this.status === 0) {
                     progress = { loaded: 0, total: 0 };
                     event =
@@ -557,10 +559,7 @@ function fakeXMLHttpRequestFor(globalScope) {
                 this.dispatchEvent(
                     new sinonEvent.ProgressEvent("loadend", progress, this)
                 );
-                return;
             }
-
-            this.dispatchEvent(readyStateChangeEvent);
         },
 
         // Ref https://xhr.spec.whatwg.org/#the-setrequestheader()-method

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -553,9 +553,11 @@ function fakeXMLHttpRequestFor(globalScope) {
                 this.dispatchEvent(
                     new sinonEvent.ProgressEvent(event, progress, this)
                 );
+                this.dispatchEvent(readyStateChangeEvent);
                 this.dispatchEvent(
                     new sinonEvent.ProgressEvent("loadend", progress, this)
                 );
+                return;
             }
 
             this.dispatchEvent(readyStateChangeEvent);

--- a/lib/fake-xhr/index.test.js
+++ b/lib/fake-xhr/index.test.js
@@ -1186,6 +1186,29 @@ describe("FakeXMLHttpRequest", function() {
             assert.equals(status, 204);
             assert.equals(statusText, "No Content");
         });
+
+        it("only performs readystatechange events prior to loadend event during xhr response", function() {
+            var eventLog = [];
+            this.xhr.addEventListener("readystatechange", function() {
+                eventLog.push({
+                    event: "readystatechange",
+                    timestamp: Date.now()
+                });
+            });
+            this.xhr.addEventListener("loadend", function() {
+                eventLog.push({ event: "loadend", timestamp: Date.now() });
+            });
+            this.xhr.respond(200);
+
+            // Loadend is last event
+            assert.equals(eventLog[eventLog.length - 1].event, "loadend");
+            // Only 1 loadend event occurs
+            assert.equals(
+                eventLog.filter(item => item.event !== "readystatechange")
+                    .length,
+                1
+            );
+        });
     });
 
     describe(".getResponseHeader", function() {


### PR DESCRIPTION
### Purpose
Fix the process flow where a `readystatechange` event should not be triggered after `loadend` event.  When it does, it is incompatible with some network lib(like `natty-fetch`) stated in issue #165.

I found that the code was using fall through logic which caused the extra readystatechange event to be thrown after the loadend event inside of the `readyStateChange()` function. There was logic added to delineate from a finished XHR request and throw the loadend but not to stop processing the fall through logic. I added a return statement to prevent the drop through but note that a readystatechange did have to be added prior to the loadend otherwise some requests would not resolve and it was noticeable through other unit-tests.

I added 1 unit test to replicate the issue results.

Resolves: #165 

### How to verify

1. Check out this branch
2. Run `npm install`
3. Revert fake-xhr library before bug fixes. `git reset --hard HEAD~1`
4. Run `npm test`. This branch includes 1 new unit test to accompany the error so during this test run 1 of the tests will fail.
5. Review & validate the test cases written to understand what scenarios are fixed & see writeup in issue.
6. Checkout this branch again to pull in bug fixes. `git pull`
7. Run `npm test` again. All tests will pass verifying there was no regression and the buggy scenarios were fixed.