### PR TITLE
WIP: Drop node 12, add node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12, 14, 16]
+                node-version: [14, 16, 18]
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
The failure from `FormData` is caused by `jsdom-global`, which removes it in the cleanup.

See https://github.com/rstacruz/jsdom-global/blob/master/keys.js#L122

The `jsdom-global` looks pretty dead. A quick fix would be to fork it and improve it to not destroy the new globals in Node 18.... or maybe there are better libraries out there now.

---

The `FileReader` failures are because the `FileReader` API is not available in node, and newly added global `Blob` support is enabling the codepaths that use `FileReader`.

https://github.com/nodejs/node/pull/41270

We should probably learn how to read blobs in a node native way, not using `FileReader`, and save that for browsers.