### PR TITLE
Improve error message for `setState` exception

### DIFF
--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -334,7 +334,7 @@ function fakeXMLHttpRequestFor(globalScope) {
     function verifyRequestOpened(xhr) {
         if (xhr.readyState !== FakeXMLHttpRequest.OPENED) {
             const errorMessage = xhr.readyState === FakeXMLHttpRequest.UNSENT
-                ? "INVALID_STATE_ERR - you might be trying to set the request state for a request that has been aborted, it is reccomended to check 'readyState' first..."
+                ? "INVALID_STATE_ERR - you might be trying to set the request state for a request that has already been aborted, it is recommended to check 'readyState' first..."
                 : `INVALID_STATE_ERR - ${xhr.readyState}`;
             throw new Error(errorMessage);
         }

--- a/lib/fake-xhr/index.js
+++ b/lib/fake-xhr/index.js
@@ -333,7 +333,10 @@ function fakeXMLHttpRequestFor(globalScope) {
 
     function verifyRequestOpened(xhr) {
         if (xhr.readyState !== FakeXMLHttpRequest.OPENED) {
-            throw new Error(`INVALID_STATE_ERR - ${xhr.readyState}`);
+            const errorMessage = xhr.readyState === FakeXMLHttpRequest.UNSENT
+                ? "INVALID_STATE_ERR - you might be trying to set the request state for a request that has been aborted, it is reccomended to check 'readyState' first..."
+                : `INVALID_STATE_ERR - ${xhr.readyState}`;
+            throw new Error(errorMessage);
         }
     }
 


### PR DESCRIPTION
I've been reverse engineering this library in order to understand why I get this specific error message in my tests.
Turned out that this was a race condition of aborted requests that the test code was trying to respond but the calling code already aborted this request.
After digging into this code and understanding that this was the problem, I decided to open this PR so that future developer might avoid the problem I faced.
I also didn't find a lot of information in stack overflow and so I think this is the easiest solution to this problem.
Let me know if there's anything else I need to follow in order to get this merged.