### PR TITLE
Update `@sinonjs/fake-timers` to match version in `@sinonjs/sinon`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
@@ -547,19 +547,11 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz",
-      "integrity": "sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/@sinonjs/referee": {
@@ -9041,21 +9033,11 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz",
-      "integrity": "sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "@sinonjs/referee": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^2.0.0",
-    "@sinonjs/fake-timers": "^7.0.4",
+    "@sinonjs/fake-timers": "^10.0.2",
     "@sinonjs/text-encoding": "^0.7.1",
     "just-extend": "^4.0.2",
     "path-to-regexp": "^1.7.0"


### PR DESCRIPTION
`sinon` itself currently uses `fake-timers@10` which leads to the package being pulled in twice. In addition, `@sinonjs/commons` is transitively pulled as v1.x as well, in addition to v2.x which is used by `sinon` itself.

See https://github.com/sinonjs/sinon/blob/main/package.json and https://github.com/sinonjs/sinon/blob/main/package-lock.json