### PR TITLE
feat: upgrade path-to-regexp

### DIFF
--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -4,7 +4,7 @@ var fakeXhr = require("../fake-xhr");
 var push = [].push;
 var log = require("./log");
 var configureLogError = require("../configure-logger");
-var pathToRegexp = require("path-to-regexp");
+var pathToRegexp = require("path-to-regexp").pathToRegexp;
 
 var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
 
@@ -236,10 +236,20 @@ var fakeServer = {
         }
 
         // Escape port number to prevent "named" parameters in 'path-to-regexp' module
-        if (typeof url === "string" && url !== "" && /:[0-9]+\//.test(url)) {
-            var m = url.match(/^(https?:\/\/.*?):([0-9]+\/.*)$/);
-            // eslint-disable-next-line no-param-reassign
-            url = `${m[1]}\\:${m[2]}`;
+        if (typeof url === "string" && url !== "") {
+            if (/:[0-9]+\//.test(url)) {
+                var m = url.match(/^(https?:\/\/.*?):([0-9]+\/.*)$/);
+                // eslint-disable-next-line no-param-reassign
+                url = `${m[1]}\\:${m[2]}`;
+            }
+            if (/:\/\//.test(url)) {
+                // eslint-disable-next-line no-param-reassign
+                url = url.replace("://", "\\://");
+            }
+            if (/\*/.test(url)) {
+                // eslint-disable-next-line no-param-reassign
+                url = url.replace(/\/\*/g, "/(.*)");
+            }
         }
 
         push.call(this.responses, {

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -900,7 +900,7 @@ describe("sinonFakeServer", function() {
 
         it("yields response to request function handler when url contains RegExp characters", function() {
             var handler = sinon.spy();
-            this.server.respondWith("GET", "/hello?world", handler);
+            this.server.respondWith("GET", "/hello\\?world", handler);
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello?world");
             xhr.send();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
+        "path-to-regexp": "^6.2.1"
       },
       "devDependencies": {
         "@sinonjs/eslint-config": "^4.0.5",
@@ -4204,7 +4204,8 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5562,6 +5563,15 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -6099,12 +6109,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11933,7 +11940,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -12983,6 +12991,15 @@
           "requires": {
             "@sinonjs/commons": "^1.7.0"
           }
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         }
       }
     },
@@ -13411,12 +13428,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@sinonjs/fake-timers": "^10.0.2",
     "@sinonjs/text-encoding": "^0.7.1",
     "just-extend": "^4.0.2",
-    "path-to-regexp": "^1.7.0"
+    "path-to-regexp": "^6.2.1"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --check",


### PR DESCRIPTION
This upgrades path-to-regexp to the latest version.

The behaviour has changed quite a lot since the previous version we were using. Some examples of what has changed:

- Wildcards are now subpatterns, e.g. `/foo/(.*)` rather than `/foo/*`
- Delimeters are parsed everywhere (`http://foo` would think `://foo` or something is a parameter)
- Characters need escaping, e.g. `foo?bar` must be `foo\\?bar` since you can now have optional parameters like `/foo/:bar?`

To account for this in the most backwards compatible way possible, this change does the following:

- Detects `://` in URLs and escapes it to `\\://`
- Detects `/*` in URLs and converts it to `/(.*)`
- **Breaks URLs with unescaped query strings** (i.e. `foo?bar` will no longer behave the same. you _must_ escape, `foo\\?bar`

The breaking change with query strings is because we can't really reliably replace `?` automatically with `\\?`, since consumers may legitimately want to use the new optional parameters functionality.

## Notes/questions

- We could go all in on a breaking change here and just align with `path-to-regexp`, i.e. do no detection of backwards compat stuff, just tell consumers to use `(.*)` and escape `:` from now on. Thoughts?