### PR TITLE
feat: add legacyRoutes option

### DIFF
--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -150,6 +150,7 @@ var fakeServer = {
             fakeHTTPMethods: true,
             logger: true,
             unsafeHeadersEnabled: true,
+            legacyRoutes: true,
         };
 
         // eslint-disable-next-line no-param-reassign
@@ -213,6 +214,8 @@ var fakeServer = {
 
     log: log,
 
+    legacyRoutes: true,
+
     respondWith: function respondWith(method, url, body) {
         if (arguments.length === 1 && typeof method !== "function") {
             this.response = responseArray(method);
@@ -249,6 +252,13 @@ var fakeServer = {
             if (/\*/.test(url)) {
                 // eslint-disable-next-line no-param-reassign
                 url = url.replace(/\/\*/g, "/(.*)");
+            }
+
+            if (this.legacyRoutes) {
+                if (url.includes("?")) {
+                    // eslint-disable-next-line no-param-reassign
+                    url = url.replace("?", "\\?");
+                }
             }
         }
 

--- a/lib/fake-server/index.test.js
+++ b/lib/fake-server/index.test.js
@@ -103,6 +103,15 @@ describe("sinonFakeServer", function () {
                 "fakeServer.create should not accept 'foo' settings",
             );
         });
+        it("allows the 'legacyRoutes' setting", function () {
+            var server = sinonFakeServer.create({
+                legacyRoutes: false,
+            });
+            assert(
+                server.legacyRoutes === false,
+                "fakeServer.create should accept 'legacyRoutes' setting",
+            );
+        });
     });
 
     it("fakes XMLHttpRequest", function () {
@@ -898,9 +907,22 @@ describe("sinonFakeServer", function () {
             assert(handler.calledOnce);
         });
 
-        it("yields response to request function handler when url contains RegExp characters", function () {
+        it("yields response to handler when url contains escaped RegExp characters in non-legacy mode", function () {
             var handler = sinon.spy();
+            this.server.legacyRoutes = false;
             this.server.respondWith("GET", "/hello\\?world", handler);
+            var xhr = new FakeXMLHttpRequest();
+            xhr.open("GET", "/hello?world");
+            xhr.send();
+
+            this.server.respond();
+
+            assert(handler.calledOnce);
+        });
+
+        it("yields response to handler when url contains unescaped RegExp characters in legacy mode", function () {
+            var handler = sinon.spy();
+            this.server.respondWith("GET", "/hello?world", handler);
             var xhr = new FakeXMLHttpRequest();
             xhr.open("GET", "/hello?world");
             xhr.send();


### PR DESCRIPTION
This adds the `legacyRoutes` option, defaulted to `true`.

When `legacyRoutes` is true, the `?` character will automatically be escaped:

```ts
server.respondWith('GET', '/hello?world', handler);
```

When it is false (future default), `?` has a special meaning in that it denotes which parameters in a path are optional. Due to this, it will not be escaped automatically:

```ts
server.respondWith('GET', '/hello\\?world', handler);

// so we can have optional params
server.respondWith('GET', '/hello/:param?', handler);
```

---

something like this @fatso83 maybe

though i do wonder if we could do some smarts here and auto-escape all `?` except those following a param 🤔 