### PR TITLE
Update `path-to-regexp` to 8.1.0 (fix CVE-2024-45296)

### DIFF
--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -264,7 +264,9 @@ var fakeServer = {
         push.call(this.responses, {
             method: method,
             url:
-                typeof url === "string" && url !== "" ? pathToRegexp(url).regexp : url,
+                typeof url === "string" && url !== ""
+                    ? pathToRegexp(url).regexp
+                    : url,
             response: typeof body === "function" ? body : responseArray(body),
         });
     },

--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -261,11 +261,10 @@ var fakeServer = {
                 }
             }
         }
-
         push.call(this.responses, {
             method: method,
             url:
-                typeof url === "string" && url !== "" ? pathToRegexp(url) : url,
+                typeof url === "string" && url !== "" ? pathToRegexp(url).regexp : url,
             response: typeof body === "function" ? body : responseArray(body),
         });
     },

--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -251,7 +251,7 @@ var fakeServer = {
             }
             if (/\*/.test(url)) {
                 // eslint-disable-next-line no-param-reassign
-                url = url.replace(/\/\*/g, "/(.*)");
+                url = url.replace(/\/\*/g, "/*path");
             }
 
             if (this.legacyRoutes) {

--- a/lib/fake-server/index.js
+++ b/lib/fake-server/index.js
@@ -250,6 +250,8 @@ var fakeServer = {
                 url = url.replace("://", "\\://");
             }
             if (/\*/.test(url)) {
+                // Uses the new syntax for repeating parameters in path-to-regexp,
+                // see https://github.com/pillarjs/path-to-regexp#unexpected--or-
                 // eslint-disable-next-line no-param-reassign
                 url = url.replace(/\/\*/g, "/*path");
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sinonjs/fake-timers": "^11.2.2",
         "@sinonjs/text-encoding": "^0.7.2",
         "just-extend": "^6.2.0",
-        "path-to-regexp": "^6.2.1"
+        "path-to-regexp": "^8.1.0"
       },
       "devDependencies": {
         "@sinonjs/eslint-config": "^5.0.2",
@@ -6195,9 +6195,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -13294,9 +13297,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@sinonjs/fake-timers": "^11.2.2",
     "@sinonjs/text-encoding": "^0.7.2",
     "just-extend": "^6.2.0",
-    "path-to-regexp": "^6.2.1"
+    "path-to-regexp": "^8.1.0"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --check",


### PR DESCRIPTION
Closes https://github.com/sinonjs/nise/issues/225

Changes:
- In path-to-regexp v8, wildcard syntax has changed again https://github.com/pillarjs/path-to-regexp?tab=readme-ov-file#unexpected--or-. 
  For backwards compat, replaces wildcard `*` with named wildcard `*path` 